### PR TITLE
use gopkg import for yaml instead of github

### DIFF
--- a/parsers/yaml/yaml.go
+++ b/parsers/yaml/yaml.go
@@ -2,7 +2,7 @@
 package yaml
 
 import (
-	"github.com/go-yaml/yaml"
+	"gopkg.in/yaml.v2"
 )
 
 // YAML implements a YAML parser.


### PR DESCRIPTION
the github usage causes dependency hell because the yaml package intentionally breaks itself when used from github.

For example, with a new package using koanf:

```sh
govendor fetch github.com/knadh/koanf
# repeat for the parsers, etc
# ...
go build main.go
../../vendor/github.com/knadh/koanf/parsers/yaml/yaml.go:5:2: cannot find package "github.com/go-yaml/yaml" in any of:
	/home/bdube/go/src/<>/vendor/github.com/go-yaml/yaml (vendor tree)
	/usr/local/go-1.13.4/src/github.com/go-yaml/yaml (from $GOROOT)
	/home/bdube/go/src/github.com/go-yaml/yaml (from $GOPATH)
```

Ok, so:

```sh
govendor fetch github.com/go-yaml/yaml

go build main.go
ERROR: the correct import path is gopkg.in/yaml.v2 ...
```

This PR just changes the import path for the parser to use gopkg, which alleviates this.