### PR TITLE
feat: text templates evaluation

### DIFF
--- a/evaluate/text_templates.go
+++ b/evaluate/text_templates.go
@@ -1,0 +1,85 @@
+package evaluate
+
+import (
+	"bytes"
+	"github.com/knadh/koanf"
+	"github.com/knadh/koanf/providers/confmap"
+	"log"
+	"text/template"
+)
+
+type evaluator struct {
+	values          map[string]interface{}
+	evaluatedValues map[string]interface{}
+}
+
+func (e *evaluator) evaluate(key string) interface{} {
+	return e.evaluateInner(nil, key)
+}
+
+func (e *evaluator) evaluateInner(inEvaluation []string, key string) interface{} {
+	if result, ok := e.evaluatedValues[key]; ok {
+		return result
+	}
+
+	for _, inEvaluationKey := range inEvaluation {
+		if inEvaluationKey == key {
+			log.Printf("cycle detected: %#v\n", inEvaluationKey)
+			return "<<< CYCLE-ERROR >>>"
+		}
+	}
+
+	value := e.values[key]
+
+	if valueString, isString := value.(string); isString {
+		inEvaluation = append(inEvaluation, key)
+		t, err := template.New(key).
+			Funcs(template.FuncMap{
+				"koanf": func(key string) interface{} {
+					return e.evaluateInner(inEvaluation, key)
+				},
+			}).
+			Parse(valueString)
+
+		if err != nil {
+			log.Printf("failed to evaluate %s: %s\n", valueString, err.Error())
+			return valueString
+		}
+
+		var resultBuffer bytes.Buffer
+		err = t.Execute(&resultBuffer, nil)
+
+		if err != nil {
+			log.Printf("failed to evaluate %s: %s\n", valueString, err.Error())
+			return valueString
+		}
+
+		result := resultBuffer.String()
+
+		e.evaluatedValues[key] = result
+		return result
+	} else {
+		return value
+	}
+}
+
+func TextTemplates(k *koanf.Koanf) *koanf.Koanf {
+	evaluator := evaluator{
+		values:          k.All(),
+		evaluatedValues: map[string]interface{}{},
+	}
+
+	newValues := map[string]interface{}{}
+
+	for key := range k.All() {
+		newValues[key] = evaluator.evaluate(key)
+	}
+
+	kNew := koanf.New(k.Delim())
+	err := kNew.Load(confmap.Provider(newValues, k.Delim()), nil)
+	if err != nil {
+		panic(err)
+	}
+
+	return kNew
+}

--- a/evaluate/text_templates_test.go
+++ b/evaluate/text_templates_test.go
@@ -1,0 +1,87 @@
+package evaluate
+
+import (
+	"github.com/knadh/koanf"
+	"github.com/knadh/koanf/providers/confmap"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+var defaultConfig = map[string]interface{}{
+	"app.dir": "/app/path",
+
+	"assets.dir": `{{koanf "app.dir"}}/assets`,
+
+	"notifications.enabled":       true,
+	"notifications.templates.dir": `{{koanf "assets.dir"}}/notifications`,
+}
+
+func TestTextTemplates(t *testing.T) {
+	tests := []struct {
+		name    string
+		configs []map[string]interface{}
+		want    map[string]interface{}
+	}{
+		{
+			"default",
+			[]map[string]interface{}{
+				defaultConfig,
+			},
+			map[string]interface{}{
+				"app.dir": "/app/path",
+
+				"assets.dir": "/app/path/assets",
+
+				"notifications.enabled":       true,
+				"notifications.templates.dir": `/app/path/assets/notifications`,
+			},
+		},
+		{
+			"override-app-path",
+			[]map[string]interface{}{
+				defaultConfig,
+				{
+					"app.dir": "/opt/app/path",
+				},
+			},
+			map[string]interface{}{
+				"app.dir": "/opt/app/path",
+
+				"assets.dir": "/opt/app/path/assets",
+
+				"notifications.enabled":       true,
+				"notifications.templates.dir": `/opt/app/path/assets/notifications`,
+			},
+		},
+		{
+			"override-assets-path",
+			[]map[string]interface{}{
+				defaultConfig,
+				{
+					"assets.dir": "/var/app/assets",
+				},
+			},
+			map[string]interface{}{
+				"app.dir": "/app/path",
+
+				"assets.dir": "/var/app/assets",
+
+				"notifications.enabled":       true,
+				"notifications.templates.dir": `/var/app/assets/notifications`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k := koanf.New(".")
+			for _, config := range tt.configs {
+				err := k.Load(confmap.Provider(config, ""), nil)
+				assert.Nil(t, err)
+			}
+
+			evaluetedConfig := TextTemplates(k)
+			assert.Equal(t, evaluetedConfig.All(), tt.want)
+		})
+	}
+}

--- a/koanf.go
+++ b/koanf.go
@@ -61,6 +61,11 @@ func New(delim string) *Koanf {
 	}
 }
 
+// Returns delimiter set for this instance of Koanf
+func (ko *Koanf) Delim() string {
+	return ko.delim
+}
+
 // Load takes a Provider that either provides a parsed config map[string]interface{}
 // in which case pa (Parser) can be nil, or raw bytes to be parsed, where a Parser
 // can be provided to parse.


### PR DESCRIPTION
I have implemented evaluation of text templates within configuration, because:

- I have many resource/data paths within my app,
- usually only one or two roots need to be overridden, and other can be relative,
- I don't want to hardcode relative paths resolution within my app (to make it possible to override them),

The usage is completely optional, as it's in separate package, and can be just not included if not wanted. Also, this implementation uses standard [`text/template`](https://golang.org/pkg/text/template/), and doesn't introduce any new dependency.

If the implementation doesn't match code style of this project, please let me know, I'll refactor it. And, if it is considered to be out-of-scope of this project completely, then I'll just move it to my app code, or maybe create a new library later.

Example of resolution (copied from test):

```golang
var defaultConfig = map[string]interface{}{
	"app.dir": "/app/path",
	"assets.dir": `{{koanf "app.dir"}}/assets`,

	"notifications.enabled":       true,
	"notifications.templates.dir": `{{koanf "assets.dir"}}/notifications`,
}

tests := []struct {
	name    string
	configs []map[string]interface{}
	want    map[string]interface{}
}{
	{
		"default",
		[]map[string]interface{}{
			defaultConfig,
		},
		map[string]interface{}{
			"app.dir": "/app/path",
			"assets.dir": "/app/path/assets",
			"notifications.enabled":       true,
			"notifications.templates.dir": `/app/path/assets/notifications`,
		},
	},
	{
		"override-app-path",
		[]map[string]interface{}{
			defaultConfig,
			{
				"app.dir": "/opt/app/path",
			},
		},
		map[string]interface{}{
			"app.dir": "/opt/app/path",
			"assets.dir": "/opt/app/path/assets",
			"notifications.enabled":       true,
			"notifications.templates.dir": `/opt/app/path/assets/notifications`,
		},
	},
	{
		"override-assets-path",
		[]map[string]interface{}{
			defaultConfig,
			{
				"assets.dir": "/var/app/assets",
			},
		},
		map[string]interface{}{
			"app.dir": "/app/path",
			"assets.dir": "/var/app/assets",
			"notifications.enabled":       true,
			"notifications.templates.dir": `/var/app/assets/notifications`,
		},
	},
}
```