### PR TITLE
allow parsing string with whitespace as a slice of strings

### DIFF
--- a/getters.go
+++ b/getters.go
@@ -2,6 +2,7 @@ package koanf
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -378,6 +379,8 @@ func (ko *Koanf) Strings(path string) []string {
 		out := make([]string, len(v))
 		copy(out[:], v[:])
 		return out
+	case string:
+		return strings.Split(o.(string), " ")
 	}
 	return []string{}
 }


### PR DESCRIPTION
This allows to get 'foo bar' string from ENV or command line and parse it as a slice of strings.