### PR TITLE
Add 'dotenv' style parser.

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,8 +531,8 @@ Writing Providers and Parsers are easy. See the bundled implementations in the `
 | parsers/json | `json.Parser()`                  | Parses JSON bytes into a nested map                                                                                                                       |
 | parsers/yaml | `yaml.Parser()`                  | Parses YAML bytes into a nested map                                                                                                                       |
 | parsers/toml | `toml.Parser()`                  | Parses TOML bytes into a nested map                                                                                                                       |
+| parsers/dotenv | `dotenv.Parser()`              | Parses DotEnv bytes into a flat map                                                                                                                       |
 | parsers/hcl  | `hcl.Parser(flattenSlices bool)` | Parses Hashicorp HCL bytes into a nested map. `flattenSlices` is recommended to be set to true. [Read more](https://github.com/hashicorp/hcl/issues/162). |
-
 ### Instance functions
 
 | Method                                                                 | Description                                                                                                                            |

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/fatih/structs v1.1.0
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/hashicorp/hcl v1.0.0
+	github.com/joho/godotenv v1.3.0 // indirect
 	github.com/mitchellh/mapstructure v1.2.2
 	github.com/pelletier/go-toml v1.7.0
 	github.com/rhnvrm/simples3 v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
+github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/mitchellh/mapstructure v1.2.2 h1:dxe5oCinTXiTIcfgmZecdCzPmAJKd46KsCWc35r0TV4=
 github.com/mitchellh/mapstructure v1.2.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/pelletier/go-toml v1.7.0 h1:7utD74fnzVc/cpcyy8sjrlFr5vYpypUixARcHIMIGuI=

--- a/parsers/dotenv/dotenv.go
+++ b/parsers/dotenv/dotenv.go
@@ -1,0 +1,51 @@
+// Package dotenv implements a koanf.Parser that parses DOTENV bytes as conf maps.
+package dotenv
+
+import (
+	"fmt"
+
+	"github.com/joho/godotenv"
+)
+
+// DOTENV implements a DOTENV parser.
+type DOTENV struct{}
+
+// Parser returns a DOTENV Parser.
+func Parser() *DOTENV {
+	return &DOTENV{}
+}
+
+// Unmarshal parses the given DOTENV bytes.
+func (p *DOTENV) Unmarshal(b []byte) (map[string]interface{}, error) {
+	// Unmarshal DOTENV from []byte
+	r, err := godotenv.Unmarshal(string(b))
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert a map[string]string to a map[string]interface{}
+	mp := make(map[string]interface{})
+	for k, v := range r {
+		mp[k] = v
+	}
+
+	return mp, err
+}
+
+// Marshal marshals the given config map to DOTENV bytes.
+func (p *DOTENV) Marshal(o map[string]interface{}) ([]byte, error) {
+	// Convert a map[string]interface{} to a map[string]string
+	mp := make(map[string]string)
+	for k, v := range o {
+		mp[k] = fmt.Sprint(v)
+	}
+
+	// Unmarshal to string
+	out, err := godotenv.Marshal(mp)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert to []byte and return
+	return []byte(out), nil
+}

--- a/parsers/dotenv/dotenv.go
+++ b/parsers/dotenv/dotenv.go
@@ -7,16 +7,16 @@ import (
 	"github.com/joho/godotenv"
 )
 
-// DOTENV implements a DOTENV parser.
-type DOTENV struct{}
+// DotEnv implements a DotEnv parser.
+type DotEnv struct{}
 
 // Parser returns a DOTENV Parser.
-func Parser() *DOTENV {
-	return &DOTENV{}
+func Parser() *DotEnv {
+	return &DotEnv{}
 }
 
 // Unmarshal parses the given DOTENV bytes.
-func (p *DOTENV) Unmarshal(b []byte) (map[string]interface{}, error) {
+func (p *DotEnv) Unmarshal(b []byte) (map[string]interface{}, error) {
 	// Unmarshal DOTENV from []byte
 	r, err := godotenv.Unmarshal(string(b))
 	if err != nil {
@@ -33,7 +33,7 @@ func (p *DOTENV) Unmarshal(b []byte) (map[string]interface{}, error) {
 }
 
 // Marshal marshals the given config map to DOTENV bytes.
-func (p *DOTENV) Marshal(o map[string]interface{}) ([]byte, error) {
+func (p *DotEnv) Marshal(o map[string]interface{}) ([]byte, error) {
 	// Convert a map[string]interface{} to a map[string]string
 	mp := make(map[string]string)
 	for k, v := range o {


### PR DESCRIPTION
This adds support for parsing dotenv style files into a config e.g.

```txt
key=value
anotherkey=anothervalue
```

My initial usecase is just to use the Provider / Parser interface so
that applications can use koanf to support reading from any config file
into a `map[string]interface{}`.