### PR TITLE
Add minimal tests for dotenv parser.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/fatih/structs v1.1.0
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/hashicorp/hcl v1.0.0
-	github.com/joho/godotenv v1.3.0 // indirect
+	github.com/joho/godotenv v1.3.0
 	github.com/mitchellh/mapstructure v1.2.2
 	github.com/pelletier/go-toml v1.7.0
 	github.com/rhnvrm/simples3 v0.5.0

--- a/mock/mock.env
+++ b/mock/mock.env
@@ -1,0 +1,8 @@
+lower=case
+UPPER=CASE
+MiXeD=CaSe
+COMMENT=AFTER # Comment
+# COMMENT
+MORE=vars
+quotedSpecial="j18120734xn2&*@#*&R#d1j23d*(*)"
+empty=


### PR DESCRIPTION
Very minimal copy paste tests just to get some sort of confidence around
dotenv working with the rest of the library.