### PR TITLE
Add ability to escape delimters.

### DIFF
--- a/examples/default-values/main.go
+++ b/examples/default-values/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Global koanf instance. Use "." as the key path delimiter. This can be "/" or any character.
-var k = koanf.New(".")
+var k = koanf.New(".", "")
 
 func main() {
 	// Load default values using the confmap provider.
@@ -21,7 +21,7 @@ func main() {
 	k.Load(confmap.Provider(map[string]interface{}{
 		"parent1.name": "Default Name",
 		"parent3.name": "New name here",
-	}, "."), nil)
+	}, ".", ""), nil)
 
 	// Load JSON config on top of the default values.
 	if err := k.Load(file.Provider("mock/mock.json"), json.Parser()); err != nil {

--- a/examples/read-commandline/main.go
+++ b/examples/read-commandline/main.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Global koanf instance. Use "." as the key path delimiter. This can be "/" or any character.
-var k = koanf.New(".")
+var k = koanf.New(".", "")
 
 func main() {
 	// Use the POSIX compliant pflag lib instead of Go's flag lib.

--- a/examples/read-environment/main.go
+++ b/examples/read-environment/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/knadh/koanf/providers/file"
 )
 
-var k = koanf.New(".")
+var k = koanf.New(".", "")
 
 func main() {
 	// Load JSON config.

--- a/examples/read-file/main.go
+++ b/examples/read-file/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Global koanf instance. Use "." as the key path delimiter. This can be "/" or any character.
-var k = koanf.New(".")
+var k = koanf.New(".", "")
 
 func main() {
 	// Load JSON config.

--- a/examples/read-raw-bytes/main.go
+++ b/examples/read-raw-bytes/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Global koanf instance. Use . as the key path delimiter. This can be / or anything.
-var k = koanf.New(".")
+var k = koanf.New(".", "")
 
 func main() {
 	b := []byte(`{"type": "rawbytes", "parent1": {"child1": {"type": "rawbytes"}}}`)

--- a/examples/read-s3/main.go
+++ b/examples/read-s3/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Global koanf instance. Use "." as the key path delimiter. This can be "/" or any character.
-var k = koanf.New(".")
+var k = koanf.New(".", "")
 
 func main() {
 	// Load JSON config from s3.

--- a/examples/read-struct/main.go
+++ b/examples/read-struct/main.go
@@ -7,7 +7,7 @@ import (
 	"github.com/knadh/koanf/providers/structs"
 )
 
-var k = koanf.New(".")
+var k = koanf.New(".", "")
 
 type parentStruct struct {
 	Name   string      `koanf:"name"`

--- a/examples/unmarshal-flat/main.go
+++ b/examples/unmarshal-flat/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Global koanf instance. Use . as the key path delimiter. This can be / or anything.
-var k = koanf.New(".")
+var k = koanf.New(".", "")
 
 func main() {
 	// Load JSON config.

--- a/examples/unmarshal/main.go
+++ b/examples/unmarshal/main.go
@@ -11,7 +11,7 @@ import (
 
 // Global koanf instance. Use . as the key path delimiter. This can be / or anything.
 var (
-	k      = koanf.New(".")
+	k      = koanf.New(".", "")
 	parser = json.Parser()
 )
 

--- a/koanf_test.go
+++ b/koanf_test.go
@@ -30,7 +30,8 @@ import (
 )
 
 const (
-	delim = "."
+	delim       = "."
+	delimEscape = ""
 
 	mockDir    = "mock"
 	mockJSON   = mockDir + "/mock.json"
@@ -247,15 +248,15 @@ type Case struct {
 // 'Flat' Case instances to be used in multiple tests. These will not be
 // mutated.
 var flatCases = []Case{
-	{koanf: koanf.New(delim), file: mockDotEnv, parser: dotenv.Parser(), typeName: "dotenv"},
+	{koanf: koanf.New(delim, delimEscape), file: mockDotEnv, parser: dotenv.Parser(), typeName: "dotenv"},
 }
 
 // Case instances to be used in multiple tests. These will not be mutated.
 var cases = []Case{
-	{koanf: koanf.New(delim), file: mockJSON, parser: json.Parser(), typeName: "json"},
-	{koanf: koanf.New(delim), file: mockYAML, parser: yaml.Parser(), typeName: "yml"},
-	{koanf: koanf.New(delim), file: mockTOML, parser: toml.Parser(), typeName: "toml"},
-	{koanf: koanf.New(delim), file: mockHCL, parser: hcl.Parser(true), typeName: "hcl"},
+	{koanf: koanf.New(delim, delimEscape), file: mockJSON, parser: json.Parser(), typeName: "json"},
+	{koanf: koanf.New(delim, delimEscape), file: mockYAML, parser: yaml.Parser(), typeName: "yml"},
+	{koanf: koanf.New(delim, delimEscape), file: mockTOML, parser: toml.Parser(), typeName: "toml"},
+	{koanf: koanf.New(delim, delimEscape), file: mockHCL, parser: hcl.Parser(true), typeName: "hcl"},
 }
 
 func init() {
@@ -326,7 +327,7 @@ func TestLoadFileAllKeys(t *testing.T) {
 func TestWatchFile(t *testing.T) {
 	var (
 		assert = assert.New(t)
-		k      = koanf.New(delim)
+		k      = koanf.New(delim, delimEscape)
 	)
 
 	// Create a tmp config file.
@@ -367,7 +368,7 @@ func TestWatchFile(t *testing.T) {
 func TestWatchFileSymlink(t *testing.T) {
 	var (
 		assert = assert.New(t)
-		k      = koanf.New(delim)
+		k      = koanf.New(delim, delimEscape)
 	)
 
 	// Create a symlink.
@@ -419,7 +420,7 @@ func TestLoadMerge(t *testing.T) {
 	var (
 		assert = assert.New(t)
 		// Load several types into a fresh Koanf instance.
-		k = koanf.New(delim)
+		k = koanf.New(delim, delimEscape)
 	)
 	for _, c := range cases {
 		assert.Nil(k.Load(file.Provider(c.file), c.parser),
@@ -455,7 +456,7 @@ func TestLoadMerge(t *testing.T) {
 	k.Load(confmap.Provider(map[string]interface{}{
 		"parent1.child1.type": "confmap",
 		"type":                "confmap",
-	}, "."), nil)
+	}, ".", ""), nil)
 	assert.Equal("confmap", k.String("parent1.child1.type"), "types don't match")
 	assert.Equal("confmap", k.String("type"), "types don't match")
 
@@ -469,7 +470,7 @@ func TestLoadMerge(t *testing.T) {
 func TestFlags(t *testing.T) {
 	var (
 		assert = assert.New(t)
-		k      = koanf.New(delim)
+		k      = koanf.New(delim, delimEscape)
 	)
 	assert.Nil(k.Load(file.Provider(mockJSON), json.Parser()), "error loading file")
 	k2 := k.Copy()
@@ -516,7 +517,7 @@ func TestFlags(t *testing.T) {
 func TestConfMapValues(t *testing.T) {
 	var (
 		assert = assert.New(t)
-		k      = koanf.New(delim)
+		k      = koanf.New(delim, delimEscape)
 	)
 	assert.Nil(k.Load(file.Provider(mockJSON), json.Parser()), "error loading file")
 	var (
@@ -525,7 +526,7 @@ func TestConfMapValues(t *testing.T) {
 		r1  = k.Cut("parent2").Raw()
 	)
 
-	k = koanf.New(delim)
+	k = koanf.New(delim, delimEscape)
 	assert.Nil(k.Load(file.Provider(mockJSON), json.Parser()), "error loading file")
 	var (
 		c2  = k.All()
@@ -542,7 +543,7 @@ func TestCutCopy(t *testing.T) {
 	// Instance 1.
 	var (
 		assert = assert.New(t)
-		k1     = koanf.New(delim)
+		k1     = koanf.New(delim, delimEscape)
 	)
 	assert.Nil(k1.Load(file.Provider(mockJSON), json.Parser()),
 		"error loading file")
@@ -553,7 +554,7 @@ func TestCutCopy(t *testing.T) {
 	)
 
 	// Instance 2.
-	k2 := koanf.New(delim)
+	k2 := koanf.New(delim, delimEscape)
 	assert.Nil(k2.Load(file.Provider(mockJSON), json.Parser()),
 		"error loading file")
 	var (
@@ -577,7 +578,7 @@ func TestCutCopy(t *testing.T) {
 func TestMerge(t *testing.T) {
 	var (
 		assert = assert.New(t)
-		k      = koanf.New(delim)
+		k      = koanf.New(delim, delimEscape)
 	)
 	assert.Nil(k.Load(file.Provider(mockJSON), json.Parser()),
 		"error loading file")
@@ -591,7 +592,7 @@ func TestMerge(t *testing.T) {
 	assert.NotEqual(cut1.Sprint(), cut2.Sprint(), "different cuts incorrectly match")
 
 	// Create an empty Koanf instance.
-	k2 := koanf.New(delim)
+	k2 := koanf.New(delim, delimEscape)
 
 	// Merge cut1 into it and check if they match.
 	k2.Merge(cut1)
@@ -601,7 +602,7 @@ func TestMerge(t *testing.T) {
 func TestMergeAt(t *testing.T) {
 	var (
 		assert = assert.New(t)
-		k      = koanf.New(delim)
+		k      = koanf.New(delim, delimEscape)
 	)
 	assert.Nil(k.Load(file.Provider(mockJSON), json.Parser()),
 		"error loading file")
@@ -616,16 +617,16 @@ func TestMergeAt(t *testing.T) {
 	)
 
 	// Get nested test data to merge at path
-	child2 := koanf.New(delim)
+	child2 := koanf.New(delim, delimEscape)
 	assert.Nil(child2.Load(confmap.Provider(map[string]interface{}{
 		"name":  k.String("parent2.child2.name"),
 		"empty": k.Get("parent2.child2.empty"),
-	}, delim), nil))
+	}, delim, delimEscape), nil))
 	grandChild := k.Cut("parent2.child2.grandchild2")
 
 	// Create test koanf
-	ordered := koanf.New(delim)
-	assert.Nil(ordered.Load(confmap.Provider(rootData, delim), nil))
+	ordered := koanf.New(delim, delimEscape)
+	assert.Nil(ordered.Load(confmap.Provider(rootData, delim, delimEscape), nil))
 
 	// Merge at path in order, first child2, then child2.grandchild2
 	ordered.MergeAt(child2, "child2")
@@ -633,8 +634,8 @@ func TestMergeAt(t *testing.T) {
 	assert.Equal(expected.Get(""), ordered.Get(""), "conf map mismatch")
 
 	// Create test koanf
-	reversed := koanf.New(delim)
-	assert.Nil(reversed.Load(confmap.Provider(rootData, delim), nil))
+	reversed := koanf.New(delim, delimEscape)
+	assert.Nil(reversed.Load(confmap.Provider(rootData, delim, delimEscape), nil))
 
 	// Merge at path in reverse order, first child2.grandchild2, then child2
 	reversed.MergeAt(grandChild, "child2.grandchild2")
@@ -667,7 +668,7 @@ func TestUnmarshal(t *testing.T) {
 	// Unmarshal and check all parsers.
 	for _, c := range cases {
 		var (
-			k  = koanf.New(delim)
+			k  = koanf.New(delim, delimEscape)
 			ts testStruct
 		)
 		assert.Nil(k.Load(file.Provider(c.file), c.parser),
@@ -704,7 +705,7 @@ func TestUnmarshalFlat(t *testing.T) {
 
 	// Unmarshal and check all parsers.
 	for _, c := range cases {
-		k := koanf.New(delim)
+		k := koanf.New(delim, delimEscape)
 		assert.Nil(k.Load(file.Provider(c.file), c.parser),
 			fmt.Sprintf("error loading: %v", c.file))
 		ts := testStructFlat{}
@@ -725,7 +726,7 @@ func TestMarshal(t *testing.T) {
 		}
 
 		// Load config.
-		k := koanf.New(delim)
+		k := koanf.New(delim, delimEscape)
 		assert.NoError(k.Load(file.Provider(c.file), c.parser),
 			fmt.Sprintf("error loading: %v", c.file))
 
@@ -734,7 +735,7 @@ func TestMarshal(t *testing.T) {
 		assert.NoError(err, "error marshalling")
 
 		// Reload raw serialize bytes into a new koanf instance.
-		k = koanf.New(delim)
+		k = koanf.New(delim, delimEscape)
 		assert.NoError(k.Load(rawbytes.Provider(b), c.parser),
 			fmt.Sprintf("error loading: %v", c.file))
 
@@ -789,8 +790,8 @@ func TestSlices(t *testing.T) {
 		"another": "123"
 	}`), &mp)
 	assert.NoError(err, "error marshalling test payload")
-	k := koanf.New(delim)
-	assert.NoError(k.Load(confmap.Provider(mp, "."), nil))
+	k := koanf.New(delim, delimEscape)
+	assert.NoError(k.Load(confmap.Provider(mp, ".", ""), nil))
 
 	assert.Empty(k.Slices("x"))
 	assert.Empty(k.Slices("parent.value"))

--- a/maps/maps.go
+++ b/maps/maps.go
@@ -36,7 +36,7 @@ func Flatten(m map[string]interface{}, keys []string, delim, delimEscape string)
 		escKey := key
 		// Escape delim in key, if delim is valid.
 		if strings.Contains(delimEscape, delim) {
-			escKey = strings.ReplaceAll(key, delim, delimEscape)
+			escKey = strings.Replace(key, delim, delimEscape, -1)
 		}
 		kp = append(kp, escKey)
 

--- a/maps/maps_test.go
+++ b/maps/maps_test.go
@@ -42,9 +42,10 @@ var testMap2 = map[string]interface{}{
 }
 
 const delim = "."
+const delimEscape = ".."
 
 func TestFlatten(t *testing.T) {
-	f, k := Flatten(testMap, nil, delim)
+	f, k := Flatten(testMap, nil, delim, delimEscape)
 	assert.Equal(t, map[string]interface{}{
 		"parent.child.key":            123,
 		"parent.child.key..with..dot": 456,
@@ -60,12 +61,12 @@ func TestFlatten(t *testing.T) {
 }
 
 func TestUnflatten(t *testing.T) {
-	m, _ := Flatten(testMap, nil, delim)
-	um := Unflatten(m, delim)
+	m, _ := Flatten(testMap, nil, delim, delimEscape)
+	um := Unflatten(m, delim, delimEscape)
 	assert.Equal(t, um, testMap)
 
-	m, _ = Flatten(testMap2, nil, delim)
-	um = Unflatten(m, delim)
+	m, _ = Flatten(testMap2, nil, delim, delimEscape)
+	um = Unflatten(m, delim, delimEscape)
 	assert.Equal(t, um, testMap2)
 }
 

--- a/maps/maps_test.go
+++ b/maps/maps_test.go
@@ -36,6 +36,9 @@ var testMap2 = map[string]interface{}{
 	},
 	"top":   789,
 	"empty": map[string]interface{}{},
+	"key.with": map[string]interface{}{
+		"delim.character": true,
+	},
 }
 
 const delim = "."
@@ -43,23 +46,23 @@ const delim = "."
 func TestFlatten(t *testing.T) {
 	f, k := Flatten(testMap, nil, delim)
 	assert.Equal(t, map[string]interface{}{
-		"parent.child.key":          123,
-		"parent.child.key.with.dot": 456,
-		"top":                       789,
-		"empty":                     map[string]interface{}{},
+		"parent.child.key":            123,
+		"parent.child.key..with..dot": 456,
+		"top":                         789,
+		"empty":                       map[string]interface{}{},
 	}, f)
 	assert.Equal(t, map[string][]string{
-		"parent.child.key":          {"parent", "child", "key"},
-		"parent.child.key.with.dot": {"parent", "child", "key.with.dot"},
-		"top":                       {"top"},
-		"empty":                     {"empty"},
+		"parent.child.key":            {"parent", "child", "key"},
+		"parent.child.key..with..dot": {"parent", "child", "key..with..dot"},
+		"top":                         {"top"},
+		"empty":                       {"empty"},
 	}, k)
 }
 
 func TestUnflatten(t *testing.T) {
 	m, _ := Flatten(testMap, nil, delim)
 	um := Unflatten(m, delim)
-	assert.NotEqual(t, um, testMap)
+	assert.Equal(t, um, testMap)
 
 	m, _ = Flatten(testMap2, nil, delim)
 	um = Unflatten(m, delim)
@@ -87,6 +90,9 @@ func TestIntfaceKeysToStrings(t *testing.T) {
 		},
 		"top":   789,
 		"empty": map[interface{}]interface{}{},
+		"key.with": map[interface{}]interface{}{
+			"delim.character": true,
+		},
 	}
 	IntfaceKeysToStrings(m)
 	assert.Equal(t, testMap2, m)

--- a/providers/basicflag/basicflag.go
+++ b/providers/basicflag/basicflag.go
@@ -11,8 +11,9 @@ import (
 
 // Pflag implements a pflag command line provider.
 type Pflag struct {
-	delim   string
-	flagset *flag.FlagSet
+	delim       string
+	delimEscape string
+	flagset     *flag.FlagSet
 }
 
 // Provider returns a commandline flags provider that returns
@@ -33,7 +34,7 @@ func (p *Pflag) Read() (map[string]interface{}, error) {
 	p.flagset.VisitAll(func(f *flag.Flag) {
 		mp[f.Name] = f.Value.String()
 	})
-	return maps.Unflatten(mp, p.delim), nil
+	return maps.Unflatten(mp, p.delim, p.delimEscape), nil
 }
 
 // ReadBytes is not supported by the env koanf.

--- a/providers/confmap/confmap.go
+++ b/providers/confmap/confmap.go
@@ -17,11 +17,11 @@ type Confmap struct {
 // Provider returns a confmap Provider that takes a flat or nested
 // map[string]interface{}. If a delim is provided, it indicates that the
 // keys are flat and the map needs to be unflatted by delim.
-func Provider(mp map[string]interface{}, delim string) *Confmap {
+func Provider(mp map[string]interface{}, delim, delimEscape string) *Confmap {
 	cp := maps.Copy(mp)
 	maps.IntfaceKeysToStrings(cp)
 	if delim != "" {
-		cp = maps.Unflatten(cp, delim)
+		cp = maps.Unflatten(cp, delim, delimEscape)
 	}
 	return &Confmap{mp: cp}
 }

--- a/providers/env/env.go
+++ b/providers/env/env.go
@@ -12,9 +12,10 @@ import (
 
 // Env implements an environment variables provider.
 type Env struct {
-	prefix string
-	delim  string
-	cb     func(key string, value string) (string, interface{})
+	prefix      string
+	delim       string
+	delimEscape string
+	cb          func(key string, value string) (string, interface{})
 }
 
 // Provider returns an environment variables provider that returns
@@ -91,7 +92,7 @@ func (e *Env) Read() (map[string]interface{}, error) {
 
 	}
 
-	return maps.Unflatten(mp, e.delim), nil
+	return maps.Unflatten(mp, e.delim, e.delimEscape), nil
 }
 
 // Watch is not supported.

--- a/providers/posflag/posflag.go
+++ b/providers/posflag/posflag.go
@@ -13,9 +13,10 @@ import (
 
 // Posflag implements a pflag command line provider.
 type Posflag struct {
-	delim   string
-	flagset *pflag.FlagSet
-	ko      *koanf.Koanf
+	delim       string
+	delimEscape string
+	flagset     *pflag.FlagSet
+	ko          *koanf.Koanf
 }
 
 // Provider returns a commandline flags provider that returns
@@ -86,7 +87,7 @@ func (p *Posflag) Read() (map[string]interface{}, error) {
 
 		mp[f.Name] = v
 	})
-	return maps.Unflatten(mp, p.delim), nil
+	return maps.Unflatten(mp, p.delim, p.delimEscape), nil
 }
 
 // ReadBytes is not supported by the env koanf.


### PR DESCRIPTION
Through this PR, you can escape the delim in the key, like this:
```go
map.Unflatten(map[string]interface{}{"this.is..an..escaped.key": true}, ".", "..") 
```
will give you
```go
map[string]interface{}{
  "this": map[string]interface{}{
    "is.an.escaped": map[string]interface{}{
      "key": true,
    },
  },
}
```

