### PR TITLE
fix: potential panic in Load if Provider is nil

### DIFF
--- a/koanf.go
+++ b/koanf.go
@@ -71,6 +71,10 @@ func (ko *Koanf) Load(p Provider, pa Parser) error {
 		err error
 	)
 
+	if p == nil {
+		return fmt.Errorf("load received a nil provider")
+	}
+
 	// No Parser is given. Call the Provider's Read() method to get
 	// the config map.
 	if pa == nil {


### PR DESCRIPTION
In case a provider returns nil, (eg Vault provider) or is
incorrectly initialized and passed to the it can result in
a Panic. This commit adds a nil check to the Load method which
returns an error if this happens instead.

Sample panic:

```go
package main

import (
	"github.com/knadh/koanf"
	"github.com/knadh/koanf/parsers/json"
	"log"
)

func main() {
	k := koanf.New(".")
	if err := k.Load(nil, json.Parser()); err != nil {
		log.Fatalf("error loading config: %v", err)
	}

	k.Print()
}
```