### PR TITLE
chore: update Go version for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ os:
 go:
   - 1.11.x
   - 1.12.x
+  - 1.13.x
+  - 1.14.x
+  - 1.15.x
+  - 1.16.x
 
 install: go get -v ./...
 script: go test -v -cover ./...


### PR DESCRIPTION
This commit adds the latest Go versions supported
by the Gimme travis-ci tool build matrix.