### PR TITLE
Significantly reduce memory use of maps.Flatten

### DIFF
--- a/maps/maps.go
+++ b/maps/maps.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 )
 
-
 // Flatten takes a map[string]interface{} and traverses it and flattens
 // nested children into keys delimited by delim.
 //
@@ -28,6 +27,12 @@ func Flatten(m map[string]interface{}, keys []string, delim string) (map[string]
 		out    = make(map[string]interface{})
 		keyMap = make(map[string][]string)
 	)
+
+	flatten(m, keys, delim, out, keyMap)
+	return out, keyMap
+}
+
+func flatten(m map[string]interface{}, keys []string, delim string, out map[string]interface{}, keyMap map[string][]string) {
 	for key, val := range m {
 		// Copy the incoming key paths into a fresh list
 		// and append the current key in the iteration.
@@ -46,22 +51,13 @@ func Flatten(m map[string]interface{}, keys []string, delim string) (map[string]
 			}
 
 			// It's a nested map. Flatten it recursively.
-			next, parts := Flatten(cur, kp, delim)
-
-			// Copy the resultant key parts and the value maps.
-			for k, p := range parts {
-				keyMap[k] = p
-			}
-			for k, v := range next {
-				out[k] = v
-			}
+			flatten(cur, kp, delim, out, keyMap)
 		default:
 			newKey := strings.Join(kp, delim)
 			out[newKey] = val
 			keyMap[newKey] = kp
 		}
 	}
-	return out, keyMap
 }
 
 // Unflatten takes a flattened key:value map (non-nested with delimited keys)

--- a/maps/maps_test.go
+++ b/maps/maps_test.go
@@ -38,6 +38,67 @@ var testMap2 = map[string]interface{}{
 	"empty": map[string]interface{}{},
 }
 
+var testMap3 = map[string]interface{}{
+	"list": []interface{}{
+		map[string]interface{}{
+			"child": map[string]interface{}{
+				"key": 123,
+				"child": map[string]interface{}{
+					"key": 123,
+					"child": map[string]interface{}{
+						"key": 123,
+						"child": map[string]interface{}{
+							"key": 123,
+							"child": map[string]interface{}{
+								"key": 123,
+								"child": map[string]interface{}{
+									"key": 123,
+									"child": map[string]interface{}{
+										"key": 123,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		map[string]interface{}{
+			"child": map[string]interface{}{
+				"key": 123,
+				"child": map[string]interface{}{
+					"key": 123,
+				},
+			},
+		},
+	},
+	"parent": map[string]interface{}{
+		"child": map[string]interface{}{
+			"key": 123,
+			"child": map[string]interface{}{
+				"key": 123,
+				"child": map[string]interface{}{
+					"key": 123,
+					"child": map[string]interface{}{
+						"key": 123,
+						"child": map[string]interface{}{
+							"key": 123,
+						},
+					},
+				},
+			},
+		},
+	},
+	"top": 789,
+	"child": map[string]interface{}{
+		"key": 123,
+		"child": map[string]interface{}{
+			"key": 123,
+		},
+	},
+	"empty": map[string]interface{}{},
+}
+
 const delim = "."
 
 func TestFlatten(t *testing.T) {
@@ -54,6 +115,12 @@ func TestFlatten(t *testing.T) {
 		"top":                       {"top"},
 		"empty":                     {"empty"},
 	}, k)
+}
+
+func BenchmarkFlatten(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		Flatten(testMap3, nil, delim)
+	}
 }
 
 func TestUnflatten(t *testing.T) {


### PR DESCRIPTION
This patch addresses an issue where maps.Flatten would use an unreasonable amount of memory when being applied to large nested structures.

See benchmark comparison:

```
benchmark               old ns/op     new ns/op     delta
BenchmarkFlatten-16     9225          3773          -59.10%

benchmark               old allocs     new allocs     delta
BenchmarkFlatten-16     63             27             -57.14%

benchmark               old bytes     new bytes     delta
BenchmarkFlatten-16     9029          2405          -73.36%
```