### PR TITLE
Remove keyMap internal from Koanf

### DIFF
--- a/maps/maps.go
+++ b/maps/maps.go
@@ -22,17 +22,16 @@ import (
 // a slice of key parts, for eg: { "parent.child": ["parent", "child"] }. This
 // parts list is used to remember the key path's original structure to
 // unflatten later.
-func Flatten(m map[string]interface{}, keys []string, delim string) (map[string]interface{}, map[string][]string) {
+func Flatten(m map[string]interface{}, keys []string, delim string) map[string]interface{} {
 	var (
-		out    = make(map[string]interface{})
-		keyMap = make(map[string][]string)
+		out = make(map[string]interface{})
 	)
 
-	flatten(m, keys, delim, out, keyMap)
-	return out, keyMap
+	flatten(m, keys, delim, out)
+	return out
 }
 
-func flatten(m map[string]interface{}, keys []string, delim string, out map[string]interface{}, keyMap map[string][]string) {
+func flatten(m map[string]interface{}, keys []string, delim string, out map[string]interface{}) {
 	for key, val := range m {
 		// Copy the incoming key paths into a fresh list
 		// and append the current key in the iteration.
@@ -46,16 +45,14 @@ func flatten(m map[string]interface{}, keys []string, delim string, out map[stri
 			if len(cur) == 0 {
 				newKey := strings.Join(kp, delim)
 				out[newKey] = val
-				keyMap[newKey] = kp
 				continue
 			}
 
 			// It's a nested map. Flatten it recursively.
-			flatten(cur, kp, delim, out, keyMap)
+			flatten(cur, kp, delim, out)
 		default:
 			newKey := strings.Join(kp, delim)
 			out[newKey] = val
-			keyMap[newKey] = kp
 		}
 	}
 }

--- a/maps/maps_test.go
+++ b/maps/maps_test.go
@@ -102,19 +102,13 @@ var testMap3 = map[string]interface{}{
 const delim = "."
 
 func TestFlatten(t *testing.T) {
-	f, k := Flatten(testMap, nil, delim)
+	f := Flatten(testMap, nil, delim)
 	assert.Equal(t, map[string]interface{}{
 		"parent.child.key":          123,
 		"parent.child.key.with.dot": 456,
 		"top":                       789,
 		"empty":                     map[string]interface{}{},
 	}, f)
-	assert.Equal(t, map[string][]string{
-		"parent.child.key":          {"parent", "child", "key"},
-		"parent.child.key.with.dot": {"parent", "child", "key.with.dot"},
-		"top":                       {"top"},
-		"empty":                     {"empty"},
-	}, k)
 }
 
 func BenchmarkFlatten(b *testing.B) {
@@ -124,11 +118,11 @@ func BenchmarkFlatten(b *testing.B) {
 }
 
 func TestUnflatten(t *testing.T) {
-	m, _ := Flatten(testMap, nil, delim)
+	m := Flatten(testMap, nil, delim)
 	um := Unflatten(m, delim)
 	assert.NotEqual(t, um, testMap)
 
-	m, _ = Flatten(testMap2, nil, delim)
+	m = Flatten(testMap2, nil, delim)
 	um = Unflatten(m, delim)
 	assert.Equal(t, um, testMap2)
 }


### PR DESCRIPTION
As outlined in #80, Koanf keeps track of KeyMap internally even though the representation is not really needed. KeyMaps use a significant amount of memory depending on the config layout which can lead to excessive memory consumptions for large or complex configs.

This patch removes the need to keep keyMap around and therefore significantly improves performance:

```
benchmark                old ns/op     new ns/op     delta
BenchmarkLoadFile-16     146821        135027        -8.03%

benchmark                old allocs     new allocs     delta
BenchmarkLoadFile-16     679            657            -3.24%

benchmark                old bytes     new bytes     delta
BenchmarkLoadFile-16     46277         37019         -20.01%
```

BREAKING CHANGE: This PR deprecates `KeyMap` function. It still works as before but is slower.

It also removes the second return argument of `maps.Flatten` which was the KeyMap previously.