### PR TITLE
chore: adds typecheck for parser and provider implementations.

### DIFF
--- a/parsers/dotenv/dotenv.go
+++ b/parsers/dotenv/dotenv.go
@@ -5,10 +5,13 @@ import (
 	"fmt"
 
 	"github.com/joho/godotenv"
+	"github.com/knadh/koanf"
 )
 
 // DotEnv implements a DotEnv parser.
 type DotEnv struct{}
+
+var _ koanf.Parser = (*DotEnv)(nil)
 
 // Parser returns a DOTENV Parser.
 func Parser() *DotEnv {

--- a/parsers/hcl/hcl.go
+++ b/parsers/hcl/hcl.go
@@ -6,10 +6,13 @@ import (
 	"errors"
 
 	"github.com/hashicorp/hcl"
+	"github.com/knadh/koanf"
 )
 
 // HCL implements a Hashicorp HCL parser.
 type HCL struct{ flattenSlices bool }
+
+var _ koanf.Parser = (*HCL)(nil)
 
 // Parser returns an HCL Parser.
 // flattenSlices flattens HCL structures where maps turn into

--- a/parsers/json/json.go
+++ b/parsers/json/json.go
@@ -3,10 +3,14 @@ package json
 
 import (
 	"encoding/json"
+
+	"github.com/knadh/koanf"
 )
 
 // JSON implements a JSON parser.
 type JSON struct{}
+
+var _ koanf.Parser = (*JSON)(nil)
 
 // Parser returns a JSON Parser.
 func Parser() *JSON {

--- a/parsers/toml/toml.go
+++ b/parsers/toml/toml.go
@@ -4,11 +4,14 @@ package toml
 import (
 	"bytes"
 
+	"github.com/knadh/koanf"
 	"github.com/pelletier/go-toml"
 )
 
 // TOML implements a TOML parser.
 type TOML struct{}
+
+var _ koanf.Parser = (*TOML)(nil)
 
 // Parser returns a TOML Parser.
 func Parser() *TOML {

--- a/parsers/yaml/yaml.go
+++ b/parsers/yaml/yaml.go
@@ -2,11 +2,14 @@
 package yaml
 
 import (
+	"github.com/knadh/koanf"
 	"gopkg.in/yaml.v2"
 )
 
 // YAML implements a YAML parser.
 type YAML struct{}
+
+var _ koanf.Parser = (*YAML)(nil)
 
 // Parser returns a YAML Parser.
 func Parser() *YAML {

--- a/providers/basicflag/basicflag.go
+++ b/providers/basicflag/basicflag.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"flag"
 
+	"github.com/knadh/koanf"
 	"github.com/knadh/koanf/maps"
 )
 
@@ -15,6 +16,8 @@ type Pflag struct {
 	flagset *flag.FlagSet
 	cb      func(key string, value string) (string, interface{})
 }
+
+var _ koanf.Provider = (*Pflag)(nil)
 
 // Provider returns a commandline flags provider that returns
 // a nested map[string]interface{} of environment variable where the

--- a/providers/confmap/confmap.go
+++ b/providers/confmap/confmap.go
@@ -6,6 +6,7 @@ package confmap
 import (
 	"errors"
 
+	"github.com/knadh/koanf"
 	"github.com/knadh/koanf/maps"
 )
 
@@ -13,6 +14,8 @@ import (
 type Confmap struct {
 	mp map[string]interface{}
 }
+
+var _ koanf.Provider = (*Confmap)(nil)
 
 // Provider returns a confmap Provider that takes a flat or nested
 // map[string]interface{}. If a delim is provided, it indicates that the

--- a/providers/env/env.go
+++ b/providers/env/env.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/knadh/koanf"
 	"github.com/knadh/koanf/maps"
 )
 
@@ -16,6 +17,8 @@ type Env struct {
 	delim  string
 	cb     func(key string, value string) (string, interface{})
 }
+
+var _ koanf.Provider = (*Env)(nil)
 
 // Provider returns an environment variables provider that returns
 // a nested map[string]interface{} of environment variable where the

--- a/providers/file/file.go
+++ b/providers/file/file.go
@@ -11,12 +11,15 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
+	"github.com/knadh/koanf"
 )
 
 // File implements a File provider.
 type File struct {
 	path string
 }
+
+var _ koanf.Provider = (*File)(nil)
 
 // Provider returns a file provider.
 func Provider(path string) *File {

--- a/providers/fs/fs.go
+++ b/providers/fs/fs.go
@@ -10,6 +10,8 @@ import (
 	"errors"
 	"io/fs"
 	"io/ioutil"
+
+	"github.com/knadh/koanf"
 )
 
 // FS implements an fs.FS provider.
@@ -17,6 +19,8 @@ type FS struct {
 	fs   fs.FS
 	path string
 }
+
+var _ koanf.Provider = (*FS)(nil)
 
 // Provider returns an fs.FS provider.
 func Provider(fs fs.FS, filepath string) *FS {

--- a/providers/posflag/posflag.go
+++ b/providers/posflag/posflag.go
@@ -19,6 +19,8 @@ type Posflag struct {
 	cb      func(key string, value string) (string, interface{})
 }
 
+var _ koanf.Provider = (*Posflag)(nil)
+
 // Provider returns a commandline flags provider that returns
 // a nested map[string]interface{} of environment variable where the
 // nesting hierarchy of keys are defined by delim. For instance, the

--- a/providers/rawbytes/rawbytes.go
+++ b/providers/rawbytes/rawbytes.go
@@ -4,12 +4,16 @@ package rawbytes
 
 import (
 	"errors"
+
+	"github.com/knadh/koanf"
 )
 
 // RawBytes implements a raw bytes provider.
 type RawBytes struct {
 	b []byte
 }
+
+var _ koanf.Provider = (*RawBytes)(nil)
 
 // Provider returns a provider that takes a raw []byte slice to be parsed
 // by a koanf.Parser parser. This should be a nested conf map, like the

--- a/providers/s3/s3.go
+++ b/providers/s3/s3.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"log"
 
+	"github.com/knadh/koanf"
 	"github.com/rhnvrm/simples3"
 )
 
@@ -36,6 +37,8 @@ type S3 struct {
 	s3  *simples3.S3
 	cfg Config
 }
+
+var _ koanf.Provider = (*S3)(nil)
 
 // Provider returns a provider that takes a simples3 config.
 func Provider(cfg Config) *S3 {

--- a/providers/structs/structs.go
+++ b/providers/structs/structs.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 
 	"github.com/fatih/structs"
+	"github.com/knadh/koanf"
 )
 
 // Structs implements a structs provider.
@@ -13,6 +14,8 @@ type Structs struct {
 	s   interface{}
 	tag string
 }
+
+var _ koanf.Provider = (*Structs)(nil)
 
 // Provider returns a provider that takes a  takes a struct and a struct tag
 // and uses structs to parse and provide it to koanf.

--- a/providers/vault/vault.go
+++ b/providers/vault/vault.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/vault/api"
+	"github.com/knadh/koanf"
 )
 
 type Config struct {
@@ -28,6 +29,8 @@ type Vault struct {
 	client *api.Client
 	cfg    Config
 }
+
+var _ koanf.Provider = (*Vault)(nil)
 
 func Provider(cfg Config) *Vault {
 	httpClient := &http.Client{Timeout: cfg.Timeout}


### PR DESCRIPTION
This PR adds a typecheck for parser and provider implementations to make it explicit. This is not only good because makes it explicit waht interface to implement but also it makes it easier to follow what to expect from the structs and methods.