### PR TITLE
Allow negative integers as durations

### DIFF
--- a/getters.go
+++ b/getters.go
@@ -319,7 +319,7 @@ func (ko *Koanf) MustFloat64Map(path string) map[string]float64 {
 // that the key contains a valid numeric value.
 func (ko *Koanf) Duration(path string) time.Duration {
 	// Look for a parsable string representation first.
-	if v := ko.Int64(path); v > 0 {
+	if v := ko.Int64(path); v != 0 {
 		return time.Duration(v)
 	}
 

--- a/koanf_test.go
+++ b/koanf_test.go
@@ -78,6 +78,7 @@ var testKeys = []string{
 	"duration",
 	"empty",
 	"intbools",
+	"negative_int",
 	"orphan",
 	"parent1.boolmap.notok3",
 	"parent1.boolmap.ok1",
@@ -117,6 +118,7 @@ var testKeyMap = map[string][]string{
 	"duration":                       {"duration"},
 	"empty":                          {"empty"},
 	"intbools":                       {"intbools"},
+	"negative_int":                   {"negative_int"},
 	"orphan":                         {"orphan"},
 	"parent1":                        {"parent1"},
 	"parent1.boolmap":                {"parent1", "boolmap"},
@@ -168,6 +170,7 @@ var testAll = `bools -> [true false true]
 duration -> 3s
 empty -> map[]
 intbools -> [1 0 1]
+negative_int -> -1234
 orphan -> [red blue orange]
 parent1.boolmap.notok3 -> false
 parent1.boolmap.ok1 -> true
@@ -1060,7 +1063,7 @@ func TestGetTypes(t *testing.T) {
 		assert.Equal(time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC), c.koanf.Time("time", "2006-01-02"))
 
 		assert.Equal([]string{}, c.koanf.MapKeys("xxxx"), "map keys mismatch")
-		assert.Equal([]string{"bools", "duration", "empty", "intbools", "orphan", "parent1", "parent2", "strbool", "strbools", "time", "type"},
+		assert.Equal([]string{"bools", "duration", "empty", "intbools", "negative_int", "orphan", "parent1", "parent2", "strbool", "strbools", "time", "type"},
 			c.koanf.MapKeys(""), "map keys mismatch")
 		assert.Equal([]string{"key1", "key2", "key3"}, c.koanf.MapKeys("parent1.strmap"), "map keys mismatch")
 
@@ -1075,9 +1078,11 @@ func TestMustGetTypes(t *testing.T) {
 		// Int.
 		assert.Panics(func() { c.koanf.MustInt64("xxxx") })
 		assert.Equal(int64(1234), c.koanf.MustInt64("parent1.id"))
+		assert.Equal(int64(-1234), c.koanf.MustInt64("negative_int"))
 
 		assert.Panics(func() { c.koanf.MustInt("xxxx") })
 		assert.Equal(int(1234), c.koanf.MustInt("parent1.id"))
+		assert.Equal(int(-1234), c.koanf.MustInt("negative_int"))
 
 		assert.Panics(func() { c.koanf.MustInt64s("xxxx") })
 		assert.Equal([]int64{1, 2, 3}, c.koanf.MustInt64s("parent1.child1.grandchild1.ids"))
@@ -1136,6 +1141,7 @@ func TestMustGetTypes(t *testing.T) {
 		assert.Panics(func() { c.koanf.MustDuration("xxxx") })
 		assert.Equal(time.Duration(1234), c.koanf.MustDuration("parent1.id"))
 		assert.Equal(time.Second*3, c.koanf.MustDuration("duration"))
+		assert.Equal(time.Duration(-1234), c.koanf.MustDuration("negative_int"))
 
 		assert.Panics(func() { c.koanf.MustTime("xxxx", "2006-01-02") })
 		assert.Equal(time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC), c.koanf.MustTime("time", "2006-01-02"))

--- a/mock/mock.hcl
+++ b/mock/mock.hcl
@@ -55,4 +55,5 @@
 "strbools" = ["1", "t", "f"]
 "time" = "2019-01-01"
 "duration" = "3s"
+"negative_int" = -1234
 "type" = "hcl"

--- a/mock/mock.json
+++ b/mock/mock.json
@@ -56,5 +56,6 @@
     "strbools": ["1", "t", "f"],
     "strbool": "1",
     "time": "2019-01-01",
-    "duration": "3s"
+    "duration": "3s",
+    "negative_int": -1234
 }

--- a/mock/mock.toml
+++ b/mock/mock.toml
@@ -22,6 +22,7 @@ strbools = [
 strbool = "1"
 time = "2019-01-01"
 duration = "3s"
+negative_int = -1234
 
 [parent1]
 name = "parent1"

--- a/mock/mock.yml
+++ b/mock/mock.yml
@@ -69,3 +69,4 @@ strbools:
 strbool: "1"
 time: "2019-01-01"
 duration: "3s"
+negative_int: -1234

--- a/providers/fs/fs_test.go
+++ b/providers/fs/fs_test.go
@@ -130,7 +130,7 @@ func TestFSProvider(t *testing.T) {
 		assert.Equal(time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC), c.koanf.Time("time", "2006-01-02"))
 
 		assert.Equal([]string{}, c.koanf.MapKeys("xxxx"), "map keys mismatch")
-		assert.Equal([]string{"bools", "duration", "empty", "intbools", "orphan", "parent1", "parent2", "strbool", "strbools", "time", "type"},
+		assert.Equal([]string{"bools", "duration", "empty", "intbools", "negative_int", "orphan", "parent1", "parent2", "strbool", "strbools", "time", "type"},
 			c.koanf.MapKeys(""), "map keys mismatch")
 		assert.Equal([]string{"key1", "key2", "key3"}, c.koanf.MapKeys("parent1.strmap"), "map keys mismatch")
 


### PR DESCRIPTION
Hi!

the `Duration` getter currently allows the passed value to be an positive integer or a parsable duration string.
So that if I pass an integer like `1` I get the same results as if I would pass `1ns`.

But Golang allows us to have negative duration, e.g. `time.ParseDuration("-1ns")`.
Passing the duration string `-1ns` works with `konaf` as expected, but if I pass `-1` it will return me a duration with the length of zero.

We stumbled about this unexpected behavior in this issue: https://github.com/ory/hydra/issues/2651#issuecomment-897590655

For consistency reasons I would propose to allow negative integers and treat them in the same way as positive ones.

What do you think?

