### PR TITLE
Refactor the posflag provider to make pflag parsing pluggable.

### DIFF
--- a/providers/posflag/posflag_test.go
+++ b/providers/posflag/posflag_test.go
@@ -15,13 +15,50 @@ func posflagCallback(key string, value string) (string, interface{}) {
 	return strings.ReplaceAll(key, "-", "_"), value
 }
 
-type Example struct {
-	Key ExampleKey `koanf:"key"`
-}
+func TestLoad(t *testing.T) {
+	assert := func(t *testing.T, k *koanf.Koanf) {
+		require.Equal(t, k.String("key.one-example"), "val1")
+		require.Equal(t, k.String("key.two_example"), "val2")
+		require.Equal(t, k.Strings("key.strings"), []string{"1", "2", "3"})
+		require.Equal(t, k.Int("key.int"), 123)
+		require.Equal(t, k.Ints("key.ints"), []int{1, 2, 3})
+		require.Equal(t, k.Float64("key.float"), 123.123)
+	}
 
-type ExampleKey struct {
-	One string `koanf:"one_example"`
-	Two string `koanf:"two_example"`
+	fs := &pflag.FlagSet{}
+	fs.String("key.one-example", "val1", "")
+	fs.String("key.two_example", "val2", "")
+	fs.StringSlice("key.strings", []string{"1", "2", "3"}, "")
+	fs.Int("key.int", 123, "")
+	fs.IntSlice("key.ints", []int{1, 2, 3}, "")
+	fs.Float64("key.float", 123.123, "")
+
+	k := koanf.New(".")
+	require.Nil(t, k.Load(posflag.Provider(fs, ".", k), nil))
+	assert(t, k)
+
+	// Test load with a custom flag callback.
+	k = koanf.New(".")
+	p := posflag.ProviderWithFlag(fs, ".", k, func(f *pflag.Flag) (string, interface{}) {
+		return f.Name, posflag.FlagVal(fs, f)
+	})
+	require.Nil(t, k.Load(p, nil), nil)
+	assert(t, k)
+
+	// Test load with a custom key, val callback.
+	k = koanf.New(".")
+	p = posflag.ProviderWithValue(fs, ".", k, func(key, val string) (string, interface{}) {
+		if key == "key.float" {
+			return "", val
+		}
+		return key, val
+	})
+	require.Nil(t, k.Load(p, nil), nil)
+	require.Equal(t, k.String("key.one-example"), "val1")
+	require.Equal(t, k.String("key.two_example"), "val2")
+	require.Equal(t, k.String("key.int"), "123")
+	require.Equal(t, k.String("key.ints"), "[1,2,3]")
+	require.Equal(t, k.String("key.float"), "")
 }
 
 func TestIssue90(t *testing.T) {
@@ -30,39 +67,38 @@ func TestIssue90(t *testing.T) {
 		"key.two_example": "b struct value",
 	}
 
-	examplePosFlags := &pflag.FlagSet{}
-	examplePosFlags.String("key.one-example", "a posflag value", "")
-	examplePosFlags.String("key.two_example", "a posflag value", "")
+	fs := &pflag.FlagSet{}
+	fs.String("key.one-example", "a posflag value", "")
+	fs.String("key.two_example", "a posflag value", "")
 
 	k := koanf.New(".")
 
 	err := k.Load(confmap.Provider(exampleKeys, "."), nil)
 	require.Nil(t, err)
 
-	err = k.Load(posflag.ProviderWithValue(examplePosFlags, ".", k, posflagCallback), nil)
+	err = k.Load(posflag.ProviderWithValue(fs, ".", k, posflagCallback), nil)
 	require.Nil(t, err)
 
 	require.Equal(t, exampleKeys, k.All())
 }
 
-type Maps struct {
-	String map[string]string
-	Int    map[string]int
-	Int64  map[string]int64
-}
-
 func TestIssue100(t *testing.T) {
 	var err error
-	examplePosFlags := &pflag.FlagSet{}
-	examplePosFlags.StringToString("string", map[string]string{"k": "v"}, "")
-	examplePosFlags.StringToInt("int", map[string]int{"k": 1}, "")
-	examplePosFlags.StringToInt64("int64", map[string]int64{"k": 2}, "")
+	f := &pflag.FlagSet{}
+	f.StringToString("string", map[string]string{"k": "v"}, "")
+	f.StringToInt("int", map[string]int{"k": 1}, "")
+	f.StringToInt64("int64", map[string]int64{"k": 2}, "")
 
 	k := koanf.New(".")
 
-	err = k.Load(posflag.Provider(examplePosFlags, ".", k), nil)
+	err = k.Load(posflag.Provider(f, ".", k), nil)
 	require.Nil(t, err)
 
+	type Maps struct {
+		String map[string]string
+		Int    map[string]int
+		Int64  map[string]int64
+	}
 	maps := new(Maps)
 
 	err = k.Unmarshal("", maps)


### PR DESCRIPTION
Issue #102 describes how the large type-switch that spf13/pflag's
design forces has to be repeated externally when a key/value
transformation callback is used as value parsing is tightly coupled
inside posflag with the non-callback mode.

This patch adds `ProviderWithFlag()` that takes a new callback that
accepts a *pflag.Flag which the implementer can use however.
The provider internally will not do any opinionated value parsing.

In addition, pflag value parsing is also refactored into a reusable
function, `posflag.FlagVal()` which the callback implementer can use
if they want to avoid repeating the pflag switch case outside in their
callback.

Example:

```go
p := posflag.ProviderWithFlag(flagset, ".", ko, func(f *pflag.Flag) (string, interface{}) {
	// Transform the key in whatever manner.
	key := f.Name

	// Use FlagVal() and then transform the value, or don't use it at all
	// and add custom logic to parse the value.
	val := posflag.FlagVal(flagset, f)

	return key, val
})
```