### PR TITLE
Add nestedtext parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,11 +621,12 @@ Writing Providers and Parsers are easy. See the bundled implementations in the `
 
 | Package      | Parser                           | Description                                                                                                                                               |
 | ------------ | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| parsers/json | `json.Parser()`                  | Parses JSON bytes into a nested map                                                                                                                       |
-| parsers/yaml | `yaml.Parser()`                  | Parses YAML bytes into a nested map                                                                                                                       |
-| parsers/toml | `toml.Parser()`                  | Parses TOML bytes into a nested map                                                                                                                       |
-| parsers/dotenv | `dotenv.Parser()`              | Parses DotEnv bytes into a flat map                                                                                                                       |
-| parsers/hcl  | `hcl.Parser(flattenSlices bool)` | Parses Hashicorp HCL bytes into a nested map. `flattenSlices` is recommended to be set to true. [Read more](https://github.com/hashicorp/hcl/issues/162). |
+| parsers/json       | `json.Parser()`                  | Parses JSON bytes into a nested map                                                                                                                       |
+| parsers/yaml       | `yaml.Parser()`                  | Parses YAML bytes into a nested map                                                                                                                       |
+| parsers/toml       | `toml.Parser()`                  | Parses TOML bytes into a nested map                                                                                                                       |
+| parsers/dotenv     | `dotenv.Parser()`              | Parses DotEnv bytes into a flat map                                                                                                                       |
+| parsers/hcl        | `hcl.Parser(flattenSlices bool)` | Parses Hashicorp HCL bytes into a nested map. `flattenSlices` is recommended to be set to true. [Read more](https://github.com/hashicorp/hcl/issues/162). |
+| parsers/nestedtext | `nestedtext.Parser()`              | Parses NestedText bytes into a flat map                                                                                                                 |
 
 ### Instance functions
 

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/joho/godotenv v1.3.0
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/mitchellh/mapstructure v1.4.1
+	github.com/npillmayer/nestext v0.1.1 // indirect
 	github.com/pelletier/go-toml v1.7.0
 	github.com/rhnvrm/simples3 v0.6.1
 	github.com/spf13/pflag v1.0.5

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/joho/godotenv v1.3.0
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/mitchellh/mapstructure v1.4.1
-	github.com/npillmayer/nestext v0.1.1 // indirect
+	github.com/npillmayer/nestext v0.1.3 // indirect
 	github.com/pelletier/go-toml v1.7.0
 	github.com/rhnvrm/simples3 v0.6.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/npillmayer/nestext v0.1.1 h1:92gYnh2OO+dnXAIa/GzvkEMMpGeNRYTKRJud0HpRnYQ=
 github.com/npillmayer/nestext v0.1.1/go.mod h1:h2lrijH8jpicr25dFY+oAJLyzlya6jhnuG+zWp9L0Uk=
+github.com/npillmayer/nestext v0.1.3 h1:2dkbzJ5xMcyJW5b8wwrX+nnRNvf/Nn1KwGhIauGyE2E=
+github.com/npillmayer/nestext v0.1.3/go.mod h1:h2lrijH8jpicr25dFY+oAJLyzlya6jhnuG+zWp9L0Uk=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.7.0 h1:7utD74fnzVc/cpcyy8sjrlFr5vYpypUixARcHIMIGuI=

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,8 @@ github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
+github.com/npillmayer/nestext v0.1.1 h1:92gYnh2OO+dnXAIa/GzvkEMMpGeNRYTKRJud0HpRnYQ=
+github.com/npillmayer/nestext v0.1.1/go.mod h1:h2lrijH8jpicr25dFY+oAJLyzlya6jhnuG+zWp9L0Uk=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.7.0 h1:7utD74fnzVc/cpcyy8sjrlFr5vYpypUixARcHIMIGuI=

--- a/parsers/nestedtext/nestedtext.go
+++ b/parsers/nestedtext/nestedtext.go
@@ -1,0 +1,41 @@
+// Package nestedtext implements a koanf Parser that parses NestedText bytes as conf maps.
+package nestedtext
+
+import (
+	"bytes"
+
+	"github.com/npillmayer/nestext"
+	"github.com/npillmayer/nestext/ntenc"
+)
+
+// NT implements a NestedText parser.
+type NT struct{}
+
+// Parser returns a NestedText Parser.
+func Parser() *NT {
+	return &NT{}
+}
+
+// Unmarshal parses the given NestedText bytes.
+//
+// If the NT content does not reflect a dict (NT allows for top-level lists or strings as well),
+// the content will be wrapped into a dict with a single key named "dict".
+func (p *NT) Unmarshal(b []byte) (map[string]interface{}, error) {
+	r := bytes.NewReader(b)
+	result, err := nestext.Parse(r, nestext.TopLevel("dict"))
+	if err != nil {
+		return nil, err
+	}
+	return result.(map[string]interface{}), nil
+
+}
+
+// Marshal marshals the given config map to NestedText bytes.
+func (p *NT) Marshal(m map[string]interface{}) ([]byte, error) {
+	buf := &bytes.Buffer{}
+	_, err := ntenc.Encode(m, buf)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/parsers/nestedtext/nestedtext.go
+++ b/parsers/nestedtext/nestedtext.go
@@ -19,7 +19,7 @@ func Parser() *NT {
 // Unmarshal parses the given NestedText bytes.
 //
 // If the NT content does not reflect a dict (NT allows for top-level lists or strings as well),
-// the content will be wrapped into a dict with a single key named "dict".
+// the content will be wrapped into a dict with a single key named "nestedtext".
 func (p *NT) Unmarshal(b []byte) (map[string]interface{}, error) {
 	r := bytes.NewReader(b)
 	result, err := nestext.Parse(r, nestext.TopLevel("dict"))

--- a/parsers/nestedtext/nestedtext.go
+++ b/parsers/nestedtext/nestedtext.go
@@ -3,6 +3,7 @@ package nestedtext
 
 import (
 	"bytes"
+	"errors"
 
 	"github.com/npillmayer/nestext"
 	"github.com/npillmayer/nestext/ntenc"
@@ -26,14 +27,20 @@ func (p *NT) Unmarshal(b []byte) (map[string]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	return result.(map[string]interface{}), nil
-
+	// Given option-parameter TopLevel, nestext.Parse is guaranteed to wrap the return value
+	// in an appropriate type (dict = map[string]interface{} in this case), if necessary.
+	// However, guard against type conversion failure anyway.
+	rmap, ok := result.(map[string]interface{})
+	if !ok {
+		return nil, errors.New("NestedText configuration expected to be a dict at top-level")
+	}
+	return rmap, nil
 }
 
 // Marshal marshals the given config map to NestedText bytes.
 func (p *NT) Marshal(m map[string]interface{}) ([]byte, error) {
-	buf := &bytes.Buffer{}
-	_, err := ntenc.Encode(m, buf)
+	var buf bytes.Buffer
+	_, err := ntenc.Encode(m, &buf)
 	if err != nil {
 		return nil, err
 	}

--- a/parsers/nestedtext/nt_test.go
+++ b/parsers/nestedtext/nt_test.go
@@ -1,0 +1,38 @@
+package nestedtext_test
+
+import (
+	"testing"
+
+	"github.com/knadh/koanf/parsers/nestedtext"
+)
+
+func TestParser(t *testing.T) {
+	// test input in NestedText format
+	ntsource := `ports:
+  - 6483
+  - 8020
+  - 9332
+timeout: 20
+`
+	// Test decoder
+	nt := nestedtext.Parser()
+	c, err := nt.Unmarshal([]byte(ntsource))
+	if err != nil {
+		t.Fatal("Unmarshal of NestedText input failed")
+	}
+	t.Logf("config-tree: %#v", c)
+	timeout := c["timeout"]
+	if timeout != "20" {
+		t.Errorf("expected timeout-parameter to be 20, is %q", timeout)
+	}
+
+	// test encoder
+	out, err := nt.Marshal(c)
+	if err != nil {
+		t.Fatal("Marshal of config to NestedText failed")
+	}
+	t.Logf("config-text: %q", string(out))
+	if string(out) != ntsource {
+		t.Errorf("expected output of Marshal(…) to equal input to Unmarshal(…); didn't")
+	}
+}

--- a/parsers/nestedtext/nt_test.go
+++ b/parsers/nestedtext/nt_test.go
@@ -20,9 +20,9 @@ timeout: 20
 	if err != nil {
 		t.Fatal("Unmarshal of NestedText input failed")
 	}
-	t.Logf("config-tree: %#v", c)
 	timeout := c["timeout"]
 	if timeout != "20" {
+		t.Logf("config-tree: %#v", c)
 		t.Errorf("expected timeout-parameter to be 20, is %q", timeout)
 	}
 
@@ -31,8 +31,8 @@ timeout: 20
 	if err != nil {
 		t.Fatal("Marshal of config to NestedText failed")
 	}
-	t.Logf("config-text: %q", string(out))
 	if string(out) != ntsource {
+		t.Logf("config-text: %q", string(out))
 		t.Errorf("expected output of Marshal(…) to equal input to Unmarshal(…); didn't")
 	}
 }


### PR DESCRIPTION
Hi,

this is a pull request to include NestedText into the list of pre-defined koanf Parsers. As explained in the accompanying issue, NestedText is a relatively new configuration file format currently having great success in the Python world. This parser wraps an implementation of a decoder/encoder in Go.

All the best,
--Norbert