### PR TITLE
feat: add optional delim to structs provider

### DIFF
--- a/providers/structs/structs.go
+++ b/providers/structs/structs.go
@@ -6,18 +6,26 @@ import (
 	"errors"
 
 	"github.com/fatih/structs"
+	"github.com/knadh/koanf/maps"
 )
 
 // Structs implements a structs provider.
 type Structs struct {
-	s   interface{}
-	tag string
+	s     interface{}
+	tag   string
+	delim string
 }
 
 // Provider returns a provider that takes a  takes a struct and a struct tag
 // and uses structs to parse and provide it to koanf.
 func Provider(s interface{}, tag string) *Structs {
 	return &Structs{s: s, tag: tag}
+}
+
+// ProviderWithDelim returns a provider that takes a takes a struct and a struct tag
+// along with a delim and uses structs to parse and provide it to koanf.
+func ProviderWithDelim(s interface{}, tag, delim string) *Structs {
+	return &Structs{s: s, tag: tag, delim: delim}
 }
 
 // ReadBytes is not supported by the structs provider.
@@ -30,7 +38,13 @@ func (s *Structs) Read() (map[string]interface{}, error) {
 	ns := structs.New(s.s)
 	ns.TagName = s.tag
 
-	return ns.Map(), nil
+	out := ns.Map()
+
+	if s.delim != "" {
+		out = maps.Unflatten(out, s.delim)
+	}
+
+	return out, nil
 }
 
 // Watch is not supported by the structs provider.

--- a/providers/structs/structs_test.go
+++ b/providers/structs/structs_test.go
@@ -26,10 +26,17 @@ type testStruct struct {
 	Parent1 parentStruct      `koanf:"parent1"`
 }
 
+type testStructWithDelim struct {
+	Endpoint string `koanf:"conf_endpoint"`
+	Username string `koanf:"conf_creds.username"`
+	Password string `koanf:"conf_creds.password"`
+}
+
 func TestStructs_Read(t *testing.T) {
 	type fields struct {
-		s   interface{}
-		tag string
+		s     interface{}
+		tag   string
+		delim string
 	}
 	tests := []struct {
 		name    string
@@ -78,12 +85,33 @@ func TestStructs_Read(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "read delim struct",
+			fields: fields{
+				s: testStructWithDelim{
+					Endpoint: "test_endpoint",
+					Username: "test_username",
+					Password: "test_password",
+				},
+				tag:   "koanf",
+				delim: ".",
+			},
+			want: map[string]interface{}{
+				"conf_creds": map[string]interface{}{
+					"password": "test_password",
+					"username": "test_username",
+				},
+				"conf_endpoint": "test_endpoint",
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &Structs{
-				s:   tt.fields.s,
-				tag: tt.fields.tag,
+				s:     tt.fields.s,
+				tag:   tt.fields.tag,
+				delim: tt.fields.delim,
 			}
 			got, err := s.Read()
 			if (err != nil) != tt.wantErr {


### PR DESCRIPTION
This commit adds a new feature to the structs provider which takes an
optional delimiter. In case a delimiter is provided, the structs
provider will apply koanf/maps.Unflatten which will unflatten the map
returned by the fatih/structs package.

To maintain backward compatibility this is added as an optional
behavior instead.

Closes: https://github.com/knadh/koanf/issues/122