### PR TITLE
feat(appconfig): add new ProviderWithClient initialiser

### DIFF
--- a/providers/appconfig/appconfig.go
+++ b/providers/appconfig/appconfig.go
@@ -92,6 +92,12 @@ func Provider(cfg Config) *AppConfig {
 	return &AppConfig{client: client, config: cfg}
 }
 
+// ProviderWithClient returns an AWS AppConfig provider
+// using an existing AWS appconfig client.
+func ProviderWithClient(cfg Config, client *appconfig.Client) *AppConfig {
+	return &AppConfig{client: client, config: cfg}
+}
+
 // ReadBytes returns the raw bytes for parsing.
 func (ac *AppConfig) ReadBytes() ([]byte, error) {
 	ac.input = appconfig.GetConfigurationInput{


### PR DESCRIPTION
There are lots of options when it comes to creating the AWS config object. The appconfig provider supports a couple of ways of doing it from scratch, but unfortunately didn't have the options I needed.

Rather than complicate the provider more, I decided the best way to address this was to add an alternative initialiser - `ProviderWithClient` which takes a pre-created appconfig client object and uses that.