### PR TITLE
Add failing test cases for merging slices

### DIFF
--- a/maps/maps_test.go
+++ b/maps/maps_test.go
@@ -210,6 +210,33 @@ func TestMerge(t *testing.T) {
 	assert.Equal(t, out, m1)
 }
 
+func TestMergeArray(t *testing.T) {
+	m1 := map[string]interface{}{
+		"arrInterface":    []interface{}{3, 3, 3, 4},
+		"arrObj":          []int{3, 3, 3, 4},
+		"arrInt":          []interface{}{3, 3, 3, 4},
+		"arrMap":          []map[string]interface{}{{"foo": "bar"}},
+		"arrInterfaceMap": []interface{}{map[string]interface{}{"foo": "bar"}},
+	}
+	m2 := map[string]interface{}{
+		"arrInterface":    []interface{}{1, 2, 3},
+		"arrObj":          []int{1, 2, 3},
+		"arrInt":          []interface{}{1, 2, 3},
+		"arrMap":          []map[string]interface{}{{"baz": "bar"}},
+		"arrInterfaceMap": []interface{}{map[string]interface{}{"baz": "bar"}},
+	}
+	Merge(m2, m1)
+
+	out := map[string]interface{}{
+		"arrInterface":    []interface{}{1, 2, 3, 4},
+		"arrObj":          []int{1, 2, 3, 4},
+		"arrInt":          []interface{}{1, 2, 3, 4},
+		"arrMap":          []map[string]interface{}{{"foo": "bar", "baz": "bar"}},
+		"arrInterfaceMap": []interface{}{map[string]interface{}{"foo": "bar", "baz": "bar"}},
+	}
+	assert.Equal(t, out, m1)
+}
+
 func TestMergeStrict(t *testing.T) {
 	m1 := map[string]interface{}{
 		"parent": map[string]interface{}{

--- a/providers/fs/fs.go
+++ b/providers/fs/fs.go
@@ -2,6 +2,7 @@
 // from given fs.FS to be used with a koanf.Parser to parse
 // into conf maps.
 
+//go:build go1.16
 // +build go1.16
 
 package fs

--- a/providers/fs/fs_test.go
+++ b/providers/fs/fs_test.go
@@ -1,3 +1,4 @@
+//go:build go1.16
 // +build go1.16
 
 package fs_test


### PR DESCRIPTION
I added failing test cases for #125 . Not sure how @knadh would like to handle this? I understand that merging slices is pretty challenging (do we replace, add, or merge?). But maybe, similar to strict merge, we could have an option for this?

However, as it is currently, it is not possible to merge slices from different sources in config management. This can be difficult when loading something from, for example, a file and the env and those are both slices. This is in particular difficult if we have a config file such as this one:

```
providers:
  - id: google
     client_id: 1234
```

and we want to load the `client_secret` from an environment variable:

```
PROVIDERS_0_CLIENT_SECRET=...
```

This use case is currently not possible to solve as `PROVIDERS_0_CLIENT_SECRET` would override the config file and result in:

```
providers:
  - id: google
     client_secret: ...
```