### PR TITLE
Add variadic options parameter to `Load`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ koanf comes with built in support for reading configuration from files, command 
 - [Setting default values](#setting-default-values)
 - [Order of merge and key case senstivity](#order-of-merge-and-key-case-sensitivity)
 - [Custom Providers and Parsers](#custom-providers-and-parsers)
+- [Custom Merge Strategies](#custom-merge-strategies)
 - [List of Providers, Parsers, and functions](#api)
 
 ### Concepts
@@ -586,6 +587,47 @@ A Provider can provide a nested map[string]interface{} config that can be loaded
 
 Writing Providers and Parsers are easy. See the bundled implementations in the `providers` and `parses` directory.
 
+### Custom Merge Strategies
+
+Per default, Koanf will merge only maps (`map[string]interface{}`) and will override any other types (slices, strings, etc).
+If you wish to use your own merge logic, you can supply the `WithMergeFunc` option when calling `Load`:
+
+```go
+package main
+
+import (
+	"errors"
+	"log"
+
+	"github.com/knadh/koanf"
+	"github.com/knadh/koanf/maps"
+	"github.com/knadh/koanf/parsers/json"
+	"github.com/knadh/koanf/parsers/yaml"
+	"github.com/knadh/koanf/providers/file"
+)
+
+var conf = koanf.Conf{
+	Delim:       ".",
+	StrictMerge: true,
+}
+var k = koanf.NewWithConf(conf)
+
+func main() {
+	yamlPath := "mock/mock.yml"
+	if err := k.Load(file.Provider(yamlPath), yaml.Parser()); err != nil {
+		log.Fatalf("error loading config: %v", err)
+	}
+
+	jsonPath := "mock/mock.json"
+	if err := k.Load(file.Provider(jsonPath), json.Parser(), koanf.WithMergeFunc(func(src, dest map[string]interface{}) error {
+     // Your custom logic, copying values from src into dst
+     return nil
+    })); err != nil {
+		log.Fatalf("error loading config: %v", err)
+	}
+}
+```
+
 ## API
 
 ### Instantiation methods
@@ -630,21 +672,21 @@ Writing Providers and Parsers are easy. See the bundled implementations in the `
 
 ### Instance functions
 
-| Method                                                       | Description                                                  |
-| ------------------------------------------------------------ | ------------------------------------------------------------ |
-| `Load(p Provider, pa Parser) error`                          | Loads config from a Provider. If a koanf.Parser is provided, the config is assumed to be raw bytes that's then parsed with the Parser. |
-| `Keys() []string`                                            | Returns the list of flattened key paths that can be used to access config values |
-| `KeyMap() map[string][]string`                               | Returns a map of all possible key path combinations possible in the loaded nested conf map |
-| `All() map[string]interface{}`                               | Returns a flat map of flattened key paths and their corresponding config values |
-| `Raw() map[string]interface{}`                               | Returns a copy of the raw nested conf map                    |
-| `Print()`                                                    | Prints a human readable copy of the flattened key paths and their values for debugging |
-| `Sprint()`                                                   | Returns a human readable copy of the flattened key paths and their values for debugging |
-| `Cut(path string) *Koanf`                                    | Cuts the loaded nested conf map at the given path and returns a new Koanf instance with the children |
-| `Copy() *Koanf`                                              | Returns a copy of the Koanf instance                         |
-| `Merge(*Koanf)`                                              | Merges the config map of a Koanf instance into the current instance |
-| `Delete(path string)`                                        | Delete the value at the given path, and does nothing if path doesn't exist. |
-| `MergeAt(in *Koanf, path string)`                            | Merges the config map of a Koanf instance into the current instance, at the given key path. |
-| `Unmarshal(path string, o interface{}) error`                | Scans the given nested key path into a given struct (like json.Unmarshal) where fields are denoted by the `koanf` tag |
+| Method                                                                 | Description                                                  |
+|------------------------------------------------------------------------| ------------------------------------------------------------ |
+| `Load(p Provider, pa Parser, opts ...Option) error`                    | Loads config from a Provider. If a koanf.Parser is provided, the config is assumed to be raw bytes that's then parsed with the Parser. |
+| `Keys() []string`                                                      | Returns the list of flattened key paths that can be used to access config values |
+| `KeyMap() map[string][]string`                                         | Returns a map of all possible key path combinations possible in the loaded nested conf map |
+| `All() map[string]interface{}`                                         | Returns a flat map of flattened key paths and their corresponding config values |
+| `Raw() map[string]interface{}`                                         | Returns a copy of the raw nested conf map                    |
+| `Print()`                                                              | Prints a human readable copy of the flattened key paths and their values for debugging |
+| `Sprint()`                                                             | Returns a human readable copy of the flattened key paths and their values for debugging |
+| `Cut(path string) *Koanf`                                              | Cuts the loaded nested conf map at the given path and returns a new Koanf instance with the children |
+| `Copy() *Koanf`                                                        | Returns a copy of the Koanf instance                         |
+| `Merge(*Koanf)`                                                        | Merges the config map of a Koanf instance into the current instance |
+| `Delete(path string)`                                                  | Delete the value at the given path, and does nothing if path doesn't exist. |
+| `MergeAt(in *Koanf, path string)`                                      | Merges the config map of a Koanf instance into the current instance, at the given key path. |
+| `Unmarshal(path string, o interface{}) error`                          | Scans the given nested key path into a given struct (like json.Unmarshal) where fields are denoted by the `koanf` tag |
 | `UnmarshalWithConf(path string, o interface{}, c UnmarshalConf) error` | Like Unmarshal but with customizable options                 |
 
 ### Getter functions

--- a/README.md
+++ b/README.md
@@ -587,10 +587,10 @@ A Provider can provide a nested map[string]interface{} config that can be loaded
 
 Writing Providers and Parsers are easy. See the bundled implementations in the `providers` and `parses` directory.
 
-### Custom Merge Strategies
+### Custom merge strategies
 
-Per default, Koanf will merge only maps (`map[string]interface{}`) and will override any other types (slices, strings, etc).
-If you wish to use your own merge logic, you can supply the `WithMergeFunc` option when calling `Load`:
+By default, when merging two config sources using `Load()`, koanf recursively merges keys of nested maps (`map[string]interface{}`),
+while static values are overwritten (slices, strings, etc). This behaviour can be changed by providing a custom merge function with the `WithMergeFunc` option.
 
 ```go
 package main

--- a/maps/maps_test.go
+++ b/maps/maps_test.go
@@ -1,6 +1,7 @@
 package maps
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -208,6 +209,32 @@ func TestMerge(t *testing.T) {
 		"key":    "string",
 	}
 	assert.Equal(t, out, m1)
+}
+
+func TestMerge2(t *testing.T) {
+	src := map[string]interface{}{
+		"globals": map[string]interface{}{
+			"features": map[string]interface{}{
+				"testing": map[string]interface{}{
+					"enabled": false,
+				},
+			},
+		},
+	}
+
+	dest := map[string]interface{}{
+		"globals": map[string]interface{}{
+			"features": map[string]interface{}{
+				"testing": map[string]interface{}{
+					"enabled":    true,
+					"anotherKey": "value",
+				},
+			},
+		},
+	}
+
+	Merge(src, dest)
+	fmt.Println(dest)
 }
 
 func TestMergeStrict(t *testing.T) {

--- a/options.go
+++ b/options.go
@@ -1,0 +1,33 @@
+package koanf
+
+// options contains options to modify the behavior of Koanf.Load.
+type options struct {
+	merge func(a, b map[string]interface{}) error
+}
+
+// newOptions creates a new options instance.
+func newOptions(opts []Option) *options {
+	o := new(options)
+	o.apply(opts)
+	return o
+}
+
+// Option is a generic type used to modify the behavior of Koanf.Load.
+type Option func(*options)
+
+// apply the given options.
+func (o *options) apply(opts []Option) {
+	for _, opt := range opts {
+		opt(o)
+	}
+}
+
+// WithMergeFunc is an option to modify the merge behavior of Koanf.Load.
+// If unset, the default merge function is used.
+//
+// The merge function is expected to merge map src into dest (left to right).
+func WithMergeFunc(merge func(src, dest map[string]interface{}) error) Option {
+	return func(o *options) {
+		o.merge = merge
+	}
+}


### PR DESCRIPTION
This patch adds variadic option parameters to `Load`, allowing consumers to, for example, customize the merge strategy used when loading config sources.

Closes #126
Closes #125

---

As discussed @knadh  :)