### PR TITLE
fix nil pointer dereference when no callback passed to provider

### DIFF
--- a/providers/env/env.go
+++ b/providers/env/env.go
@@ -19,11 +19,11 @@ type Env struct {
 
 // Provider returns an environment variables provider that returns
 // a nested map[string]interface{} of environment variable where the
-// nesting hierarchy of keys are defined by delim. For instance, the
+// nesting hierarchy of keys is defined by delim. For instance, the
 // delim "." will convert the key `parent.child.key: 1`
 // to `{parent: {child: {key: 1}}}`.
 //
-// If prefix is specified (case sensitive), only the env vars with
+// If prefix is specified (case-sensitive), only the env vars with
 // the prefix are captured. cb is an optional callback that takes
 // a string and returns a string (the env variable name) in case
 // transformations have to be applied, for instance, to lowercase
@@ -31,13 +31,16 @@ type Env struct {
 // If the callback returns an empty string, the variable will be
 // ignored.
 func Provider(prefix, delim string, cb func(s string) string) *Env {
-	return &Env{
+	e := &Env{
 		prefix: prefix,
 		delim:  delim,
-		cb: func(key string, value string) (string, interface{}) {
-			return cb(key), value
-		},
 	}
+	if cb != nil {
+		e.cb = func(key string, value string) (string, interface{}) {
+			return cb(key), value
+		}
+	}
+	return e
 }
 
 // ProviderWithValue works exactly the same as Provider except the callback


### PR DESCRIPTION
When doing
```go
k.Load(env.Provider("", ".", nil), nil)
```

koanf always wraps the nil callback `cb`
https://github.com/knadh/koanf/blob/5f508c9ad32bce7384d5c00005f60bf5639a841b/providers/env/env.go#L33-L41

and would panic because https://github.com/knadh/koanf/blob/5f508c9ad32bce7384d5c00005f60bf5639a841b/providers/env/env.go#L81 is always true but the wrapped cb is nil.


```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x10ae7a7]

goroutine 6 [running]:
testing.tRunner.func1.2({0x14e6300, 0x24c6d40})
        /home/robin/go/go1.17.1/src/testing/testing.go:1209 +0x24e
testing.tRunner.func1()
        /home/robin/go/go1.17.1/src/testing/testing.go:1212 +0x218
panic({0x14e6300, 0x24c6d40})
        /home/robin/go/go1.17.1/src/runtime/panic.go:1038 +0x215
github.com/knadh/koanf/providers/env.Provider.func1({0xc000040000, 0x19}, {0xc000040015, 0x4})
        /home/robin/go/pkg/mod/github.com/knadh/koanf@v1.3.3/providers/env/env.go:38 +0x27
github.com/knadh/koanf/providers/env.(*Env).Read(0xc0002c0270)
        /home/robin/go/pkg/mod/github.com/knadh/koanf@v1.3.3/providers/env/env.go:82 +0x1a3
github.com/knadh/koanf.(*Koanf).Load(0x0, {0x191c880, 0xc0002c0270}, {0x0, 0x0})
        /home/robin/go/pkg/mod/github.com/knadh/koanf@v1.3.3/koanf.go:101 +0x9e
```