### PR TITLE
Add tests for env.go

### DIFF
--- a/providers/env/env_test.go
+++ b/providers/env/env_test.go
@@ -1,0 +1,44 @@
+package env
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestProvider(t *testing.T) {
+
+	testCases := []struct {
+		name    string
+		prefix  string
+		delim   string
+		cb      func(key string, value string) (string, interface{})
+		cbInput func(key string) string
+		want    *Env
+	}{
+		{
+			name:   "Nil cb",
+			prefix: "TESTVAR_",
+			delim:  ".",
+			want: &Env{
+				prefix: "TESTVAR_",
+				delim:  ".",
+			},
+		},
+		{
+			name:   "Empty string nil cb",
+			prefix: "",
+			delim:  ".",
+			want: &Env{
+				prefix: "",
+				delim:  ".",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Provider(tc.prefix, tc.delim, tc.cbInput)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Hi. I wanted to add tests for `env.go`. I added two test cases and also tried to add for non-nil cb cases but I was not succeeded to add them. I know this does not cover all cases, but this first commit can be seen as the first starting point of the `env_test.go`. I am ready to add other test cases with your help. I can refactor the code if you want as well. 

Signed-off-by: Gökhan Özeloğlu <gozeloglu@gmail.com>