### PR TITLE
Add tests for ProviderWithValue func in env.go

### DIFF
--- a/providers/env/env_test.go
+++ b/providers/env/env_test.go
@@ -113,13 +113,12 @@ func TestProviderWithValue(t *testing.T) {
 			if tc.nilCallback {
 				assert.Equal(t, tc.want, got)
 			} else {
-				kGot, vGot := got.cb("test_key_env_1", "test_val")
-				kTc, vTc := tc.want.cb("test_key_env_1", "test_val")
+				keyGot, valGot := got.cb("test_key_env_1", "test_val")
+				keyWant, valWant := tc.want.cb("test_key_env_1", "test_val")
 				assert.Equal(t, tc.prefix, got.prefix)
 				assert.Equal(t, tc.delim, got.delim)
-				assert.Equal(t, kTc, kGot)
-				assert.Equal(t, vTc, vGot)
-				assert.NotNil(t, got.cb)
+				assert.Equal(t, keyWant, keyGot)
+				assert.Equal(t, valWant, valGot)
 			}
 		})
 	}

--- a/providers/env/env_test.go
+++ b/providers/env/env_test.go
@@ -93,18 +93,14 @@ func TestProviderWithValue(t *testing.T) {
 			prefix: "TEST_",
 			delim:  ".",
 			cb: func(key string, value string) (string, interface{}) {
-				key = strings.ToLower(key)
-				key = strings.TrimPrefix(key, "test_")
-				key = strings.Replace(key, "_", ".", -1)
+				key = strings.Replace(strings.TrimPrefix(strings.ToLower(key), "test_"), "_", ".", -1)
 				return key, value
 			},
 			want: &Env{
 				prefix: "TEST_",
 				delim:  ".",
 				cb: func(key string, value string) (string, interface{}) {
-					key = strings.ToLower(key)
-					key = strings.TrimPrefix(key, "test_")
-					key = strings.Replace(key, "_", ".", -1)
+					key = strings.Replace(strings.TrimPrefix(strings.ToLower(key), "test_"), "_", ".", -1)
 					return key, value
 				},
 			},

--- a/providers/env/env_test.go
+++ b/providers/env/env_test.go
@@ -2,6 +2,7 @@ package env
 
 import (
 	"github.com/stretchr/testify/assert"
+	"strings"
 	"testing"
 )
 
@@ -39,6 +40,91 @@ func TestProvider(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := Provider(tc.prefix, tc.delim, tc.cbInput)
 			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestProviderWithValue(t *testing.T) {
+	testCases := []struct {
+		name        string
+		prefix      string
+		delim       string
+		cb          func(key string, value string) (string, interface{})
+		nilCallback bool
+		want        *Env
+	}{
+		{
+			name:        "Nil cb",
+			prefix:      "TEST_",
+			delim:       ".",
+			nilCallback: true,
+			want: &Env{
+				prefix: "TEST_",
+				delim:  ".",
+			},
+		},
+		{
+			name:        "Empty string nil cb",
+			prefix:      "",
+			delim:       ".",
+			nilCallback: true,
+			want: &Env{
+				prefix: "",
+				delim:  ".",
+			},
+		},
+		{
+			name:   "Return the same key-value pair in cb",
+			prefix: "TEST_",
+			delim:  ".",
+			cb: func(key string, value string) (string, interface{}) {
+				return key, value
+			},
+			want: &Env{
+				prefix: "TEST_",
+				delim:  ".",
+				cb: func(key string, value string) (string, interface{}) {
+					return key, value
+				},
+			},
+		},
+		{
+			name:   "Custom cb function",
+			prefix: "TEST_",
+			delim:  ".",
+			cb: func(key string, value string) (string, interface{}) {
+				key = strings.ToLower(key)
+				key = strings.TrimPrefix(key, "test_")
+				key = strings.Replace(key, "_", ".", -1)
+				return key, value
+			},
+			want: &Env{
+				prefix: "TEST_",
+				delim:  ".",
+				cb: func(key string, value string) (string, interface{}) {
+					key = strings.ToLower(key)
+					key = strings.TrimPrefix(key, "test_")
+					key = strings.Replace(key, "_", ".", -1)
+					return key, value
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ProviderWithValue(tc.prefix, tc.delim, tc.cb)
+			if tc.nilCallback {
+				assert.Equal(t, tc.want, got)
+			} else {
+				kGot, vGot := got.cb("test_key_env_1", "test_val")
+				kTc, vTc := tc.want.cb("test_key_env_1", "test_val")
+				assert.Equal(t, tc.prefix, got.prefix)
+				assert.Equal(t, tc.delim, got.delim)
+				assert.Equal(t, kTc, kGot)
+				assert.Equal(t, vTc, vGot)
+				assert.NotNil(t, got.cb)
+			}
 		})
 	}
 }


### PR DESCRIPTION
I added tests for `ProviderWithValue()` in `env.go`. I can add more test cases if you want. 

Signed-off-by: Gökhan Özeloğlu gozeloglu@gmail.com