### PR TITLE
Marshal method for HCL Parser

### DIFF
--- a/parsers/hcl/hcl.go
+++ b/parsers/hcl/hcl.go
@@ -3,9 +3,11 @@
 package hcl
 
 import (
-	"errors"
+	"bytes"
+	"encoding/json"
 
 	"github.com/hashicorp/hcl"
+	"github.com/hashicorp/hcl/hcl/printer"
 )
 
 // HCL implements a Hashicorp HCL parser.
@@ -38,27 +40,22 @@ func (p *HCL) Unmarshal(b []byte) (map[string]interface{}, error) {
 
 // Marshal marshals the given config map to HCL bytes.
 func (p *HCL) Marshal(o map[string]interface{}) ([]byte, error) {
-	return nil, errors.New("HCL marshalling is not supported")
-	// TODO: Although this is the only way to do it, it's producing empty bytes.
-	// Needs investigation.
-	// The only way to generate HCL is from the HCL node structure.
-	// Turn the map into JSON, then parse it with the HCL lib to create its
-	// structure, and then, encode to HCL.
-	// j, err := json.Marshal(o)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	// tree, err := hcl.Parse(string(j))
-	// if err != nil {
-	// 	return nil, err
-	// }
+	j, err := json.Marshal(o)
+	if err != nil {
+		return nil, err
+	}
 
-	// var buf bytes.Buffer
-	// out := bufio.NewWriter(&buf)
-	// if err := printer.Fprint(out, tree.Node); err != nil {
-	// 	return nil, err
-	// }
-	// return buf.Bytes(), err
+	tree, err := hcl.Parse(string(j))
+	if err != nil {
+		return nil, err
+	}
+
+	buf := new(bytes.Buffer)
+	if err = printer.Fprint(buf, tree); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
 }
 
 // flattenHCL flattens an unmarshalled HCL structure where maps


### PR DESCRIPTION
Changes:
1. Implemented Marshal method for HCL Parser.
2. Updated the unit test for the same.