### PR TITLE
Update gopkg.in/yaml.v2 to gopkg.in/yaml.v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,11 +15,11 @@ require (
 	github.com/joho/godotenv v1.3.0
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/mitchellh/mapstructure v1.4.1
-	github.com/npillmayer/nestext v0.1.3 // indirect
+	github.com/npillmayer/nestext v0.1.3
 	github.com/pelletier/go-toml v1.7.0
 	github.com/rhnvrm/simples3 v0.6.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sys v0.0.0-20200331124033-c3d80250170d // indirect
-	gopkg.in/yaml.v2 v2.2.8
+	gopkg.in/yaml.v3 v3.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,6 @@ github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/npillmayer/nestext v0.1.1 h1:92gYnh2OO+dnXAIa/GzvkEMMpGeNRYTKRJud0HpRnYQ=
-github.com/npillmayer/nestext v0.1.1/go.mod h1:h2lrijH8jpicr25dFY+oAJLyzlya6jhnuG+zWp9L0Uk=
 github.com/npillmayer/nestext v0.1.3 h1:2dkbzJ5xMcyJW5b8wwrX+nnRNvf/Nn1KwGhIauGyE2E=
 github.com/npillmayer/nestext v0.1.3/go.mod h1:h2lrijH8jpicr25dFY+oAJLyzlya6jhnuG+zWp9L0Uk=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
@@ -174,7 +172,8 @@ gopkg.in/square/go-jose.v2 v2.3.1 h1:SK5KegNXmKmqE342YYN2qPHEnUYeoMiXXl1poUlI+o4
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0 h1:hjy8E9ON/egN1tAYqKb61G10WtihqetD4sz2H+8nIeA=
+gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/parsers/yaml/yaml.go
+++ b/parsers/yaml/yaml.go
@@ -2,7 +2,7 @@
 package yaml
 
 import (
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // YAML implements a YAML parser.
@@ -19,6 +19,7 @@ func (p *YAML) Unmarshal(b []byte) (map[string]interface{}, error) {
 	if err := yaml.Unmarshal(b, &out); err != nil {
 		return nil, err
 	}
+
 	return out, nil
 }
 

--- a/parsers/yaml/yaml_test.go
+++ b/parsers/yaml/yaml_test.go
@@ -56,15 +56,15 @@ string: Hello World`),
 				"gold",
 				nil,
 				123,
-				map[interface{}]interface{}{"a": "b", "c": "d"},
+				map[string]interface{}{"a": "b", "c": "d"},
 				"Hello World"},
 		},
 		{
 			name: "Valid YAML - With comments",
 			input: []byte(`---
-key: #Here is a single-line comment 
+key: #Here is a single-line comment
 - value line 5
-#Here is a 
+#Here is a
 #multi-line comment
 - value line 13`),
 			keys:   []string{"key"},
@@ -128,18 +128,18 @@ number: 2
 				"string":  "Hello World",
 			},
 			output: []byte(`array:
-- 1
-- 2
-- 3
-- 4
-- 5
+    - 1
+    - 2
+    - 3
+    - 4
+    - 5
 boolean: true
 color: gold
 "null": null
 number: 123
 object:
-  a: b
-  c: d
+    a: b
+    c: d
 string: Hello World
 `),
 		},


### PR DESCRIPTION
CVE-2022-28948
An issue in the Unmarshal function in Go-Yaml v3 causes the program to crash when attempting to deserialize invalid input.
Affected versions < 3.0.0
Patched version 3.0.0

Signed-off-by: Parham Alvani [parham.alvani@gmail.com](mailto:parham.alvani@gmail.com)