### PR TITLE
updated: package installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ koanf comes with built in support for reading configuration from files, command 
 ### Installation
 
 ```shell
-go get -u github.com/knadh/koanf
+go install github.com/knadh/koanf@latest
 ```
 
 ### Contents


### PR DESCRIPTION
deprecated go get method replaced with recent method

installing go packages with `get` has expired, thats why we should update the documentation.

by the way, when you run `go install github.com/knadh/koanf@latest` this installs `v1.4.3` to GOPATH. 
So v1.4.3 should be prepared or do we suppose to replace `@latest`with `@v1.4.2` ?