### PR TITLE
Add `Set(key, val)` shorthand for `Merge()`.

### DIFF
--- a/koanf.go
+++ b/koanf.go
@@ -218,6 +218,16 @@ func (ko *Koanf) MergeAt(in *Koanf, path string) error {
 	return ko.merge(n, new(options))
 }
 
+// Set sets the value at a specific key.
+func (ko *Koanf) Set(key string, val interface{}) error {
+	// Unflatten the config map with the given key path.
+	n := maps.Unflatten(map[string]interface{}{
+		key: val,
+	}, ko.conf.Delim)
+
+	return ko.merge(n, new(options))
+}
+
 // Marshal takes a Parser implementation and marshals the config map into bytes,
 // for example, to TOML or JSON bytes.
 func (ko *Koanf) Marshal(p Parser) ([]byte, error) {

--- a/koanf_test.go
+++ b/koanf_test.go
@@ -870,6 +870,31 @@ func TestMergeAt(t *testing.T) {
 	assert.Equal(expected.Get(""), reversed.Get(""), "conf map mismatch")
 }
 
+func TestSet(t *testing.T) {
+	var (
+		assert = assert.New(t)
+		k      = koanf.New(delim)
+	)
+	assert.Nil(k.Load(file.Provider(mockYAML), yaml.Parser()),
+		"error loading file")
+
+	assert.Nil(k.Set("parent1.name", "new"))
+	assert.Equal(k.String("parent1.name"), "new")
+
+	assert.Nil(k.Set("parent1.child1.name", 123))
+	assert.Equal(k.Int("parent1.child1.name"), 123)
+
+	assert.Nil(k.Set("parent1.child1.grandchild1.ids", []int{5}))
+	assert.Equal(k.Ints("parent1.child1.grandchild1.ids"), []int{5})
+
+	assert.Nil(k.Set("parent1.child1.grandchild1", 123))
+	assert.Equal(k.Int("parent1.child1.grandchild1"), 123)
+	assert.Equal(k.Int("parent1.child1.grandchild1.ids"), 0)
+
+	assert.Nil(k.Set("parent1.child1.grandchild1", map[string]interface{}{"name": "new"}))
+	assert.Equal(k.Get("parent1.child1.grandchild1"), map[string]interface{}{"name": "new"})
+}
+
 func TestUnmarshal(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
When there are multiple mutations to be made at many places, `Load(), Merge(), MergeAt()` requires a lot of boilerplate code.

`Set(key string, val interface{})` is a new shorthand that allows a value to be directly merge at the given key without having to initialize a new Koanf{} object.

Closes #191.