### PR TITLE
chore: allow to use custom environment

### DIFF
--- a/providers/env/env.go
+++ b/providers/env/env.go
@@ -15,6 +15,9 @@ type Env struct {
 	prefix string
 	delim  string
 	cb     func(key string, value string) (string, interface{})
+	// Environ can be used to specify a different set of enviornment variables.
+	// If empty Env will use os.Environ.
+	Environ []string
 }
 
 // Provider returns an environment variables provider that returns
@@ -65,7 +68,10 @@ func (e *Env) ReadBytes() ([]byte, error) {
 func (e *Env) Read() (map[string]interface{}, error) {
 	// Collect the environment variable keys.
 	var keys []string
-	for _, k := range os.Environ() {
+	if len(e.Environ) == 0 {
+		e.Environ = os.Environ()
+	}
+	for _, k := range e.Environ {
 		if e.prefix != "" {
 			if strings.HasPrefix(k, e.prefix) {
 				keys = append(keys, k)

--- a/providers/env/env.go
+++ b/providers/env/env.go
@@ -12,10 +12,10 @@ import (
 
 // Env implements an environment variables provider.
 type Env struct {
-	prefix  string
-	delim   string
-	environ []string
-	cb      func(key string, value string) (string, interface{})
+	prefix      string
+	delim       string
+	environFunc func() []string
+	cb          func(key string, value string) (string, interface{})
 }
 
 // Provider returns an environment variables provider that returns
@@ -57,10 +57,12 @@ func ProviderWithValue(prefix, delim string, cb func(key string, value string) (
 // by using options.
 func ProviderWithOptions(options ...Option) *Env {
 	e := &Env{
-		prefix:  "",
-		delim:   ".",
-		cb:      nil,
-		environ: os.Environ(),
+		prefix: "",
+		delim:  ".",
+		cb:     nil,
+		environFunc: func() []string {
+			return os.Environ()
+		},
 	}
 
 	for _, option := range options {
@@ -79,7 +81,7 @@ func (e *Env) ReadBytes() ([]byte, error) {
 func (e *Env) Read() (map[string]interface{}, error) {
 	// Collect the environment variable keys.
 	var keys []string
-	for _, k := range e.environ {
+	for _, k := range e.environFunc() {
 		if e.prefix != "" {
 			if strings.HasPrefix(k, e.prefix) {
 				keys = append(keys, k)

--- a/providers/env/env_test.go
+++ b/providers/env/env_test.go
@@ -171,11 +171,26 @@ func TestProviderWithOptions(t *testing.T) {
 			},
 		},
 		{
-			name: "with custom environment",
+			name: "with custom environment slice",
 			options: []Option{
 				WithPrefix("TEST_"),
 				WithDelimiter("."),
 				WithEnviron([]string{"FOO=BAR"}),
+			},
+			want: &Env{
+				prefix:  "TEST_",
+				delim:   ".",
+				environ: []string{"FOO=BAR"},
+			},
+		},
+		{
+			name: "with custom environment map",
+			options: []Option{
+				WithPrefix("TEST_"),
+				WithDelimiter("."),
+				WithEnvironMap(map[string]string{
+					"FOO": "BAR",
+				}),
 			},
 			want: &Env{
 				prefix:  "TEST_",

--- a/providers/env/env_test.go
+++ b/providers/env/env_test.go
@@ -246,9 +246,8 @@ func TestRead(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := os.Setenv(tc.key, tc.value)
+			tc.Environ = []string{tc.key + "=" + tc.value}
 			assert.Nil(t, err)
-			defer os.Unsetenv(tc.key)
 
 			envs, err := tc.env.Read()
 			assert.Nil(t, err)

--- a/providers/env/options.go
+++ b/providers/env/options.go
@@ -1,0 +1,35 @@
+package env
+
+type Option func(*Env)
+
+// WithPrefix sets the environment prefix. Only the env vars with the prefix are captured.
+func WithPrefix(prefix string) Option {
+	return func(env *Env) {
+		env.prefix = prefix
+	}
+}
+
+// WithDelimiter sets the delimiter to split the environment variable into its parts.
+// For example the delimiter "." will convert the key `parent.child.key: 1`
+// to `{parent: {child: {key: 1}}}`.
+func WithDelimiter(delim string) Option {
+	return func(env *Env) {
+		env.delim = delim
+	}
+}
+
+// WithCallback sets the function that will be called for each environment variable.
+// This is useful for cases where you may want to modify the variable or value before it gets passed on.
+// If the callback returns an empty string, the variable will be
+// ignored.
+func WithCallback(cb func(key string, value string) (string, interface{})) Option {
+	return func(env *Env) {
+		env.cb = cb
+	}
+}
+
+func WithEnviron(environ []string) Option {
+	return func(env *Env) {
+		env.environ = environ
+	}
+}

--- a/providers/env/options.go
+++ b/providers/env/options.go
@@ -28,8 +28,19 @@ func WithCallback(cb func(key string, value string) (string, interface{})) Optio
 	}
 }
 
+// WithEnviron sets the environment using a traditional environment slice.
 func WithEnviron(environ []string) Option {
 	return func(env *Env) {
 		env.environ = environ
+	}
+}
+
+// WithEnvironMap sets the environment using a map.
+func WithEnvironMap(environ map[string]string) Option {
+	return func(env *Env) {
+		env.environ = make([]string, 0, len(environ))
+		for k, v := range environ {
+			env.environ = append(env.environ, k+"="+v)
+		}
 	}
 }

--- a/providers/env/options.go
+++ b/providers/env/options.go
@@ -28,19 +28,27 @@ func WithCallback(cb func(key string, value string) (string, interface{})) Optio
 	}
 }
 
+// WithEnvironFunc sets the environment using a function
+func WithEnvironFunc(environFunc func() []string) Option {
+	return func(env *Env) {
+		env.environFunc = environFunc
+	}
+}
+
 // WithEnviron sets the environment using a traditional environment slice.
 func WithEnviron(environ []string) Option {
-	return func(env *Env) {
-		env.environ = environ
-	}
+	return WithEnvironFunc(func() []string {
+		return environ
+	})
 }
 
 // WithEnvironMap sets the environment using a map.
 func WithEnvironMap(environ map[string]string) Option {
-	return func(env *Env) {
-		env.environ = make([]string, 0, len(environ))
+	return WithEnvironFunc(func() []string {
+		s := make([]string, 0, len(environ))
 		for k, v := range environ {
-			env.environ = append(env.environ, k+"="+v)
+			s = append(s, k+"="+v)
 		}
-	}
+		return s
+	})
 }


### PR DESCRIPTION
When using the `env` provider in tests it is always necessary to set environment values beforehand:

```go
func TestLoadConfig(t *testing.T) {
	k := koanf.New(".")
	os.Setenv("APP_USER", "Joe")
	os.Setenv("APP_PASSWORD", "secret")
	defer os.Unsetenv("APP_USER")
	defer os.Unsetenv("APP_PASSWORD")
	err := k.Load(env.Provider("APP_", ".", nil), nil)
	if err != nil {
		return nil, errors.Wrapf(err, "unable to load config from environment")
	}
	k.Print()
}
```

With this change it would be possible to have a pattern like this:
```go
func TestLoadConfig(t *testing.T) {
	k := koanf.New(".")
	provider := env.Provider("APP_", ".", nil)
	provider.Environ = []string{
		"APP_USER=Joe",
		"APP_PASSWORD=secret",
	}
	err := k.Load(provider, nil)
	if err != nil {
		return nil, errors.Wrapf(err, "unable to load config from environment")
	}
	k.Print()
}
```

The reason for having this is to stop pollutiong the global environment state.
Especially on test failures the current design becomes a source of problems for future tests.

--- 

Following alternatives are also possible:
1. Chaining the commands:
    ```go
    env.Provider("APP_", ".", nil).WithEnviron([]string{"APP_USER=Joe"})
   ```
2. Changing the signature:
    ```go
    env.Provider("APP_", ".", nil, []string{"APP_USER=Joe"})
   ```
    > would break existing API
3. Adding a new *init* function:
    ```go
    func ProviderWithEnviron(prefix, delim string, environ []string) *Env
   ```
   > not sure how to specific callback function then. 