### PR TITLE
feat: add flag to optionally fetch secret metadata

### DIFF
--- a/providers/vault/vault.go
+++ b/providers/vault/vault.go
@@ -34,6 +34,9 @@ type Config struct {
 
 	// Internal HTTP client timeout
 	Timeout time.Duration
+
+	// WithMeta states whether the secret should be returned with its metadata.
+	WithMeta bool
 }
 
 type Vault struct {
@@ -65,11 +68,16 @@ func (r *Vault) Read() (map[string]interface{}, error) {
 		return nil, err
 	}
 
+	s := secret.Data
+	if !r.cfg.WithMeta {
+		s = secret.Data["data"].(map[string]interface{})
+	}
+
 	if !r.cfg.FlatPaths {
-		data := maps.Unflatten(secret.Data, r.cfg.Delim)
+		data := maps.Unflatten(s, r.cfg.Delim)
 
 		return data, nil
 	}
 
-	return secret.Data, nil
+	return s, nil
 }

--- a/providers/vault/vault.go
+++ b/providers/vault/vault.go
@@ -36,6 +36,10 @@ type Config struct {
 	Timeout time.Duration
 
 	// WithMeta states whether the secret should be returned with its metadata.
+	// If WithMeta is true, the value for data `key` and the metadata `version`
+	// can be accessed as `k.String("data.key")` and `k.Int("metadata.version")`.
+	// When set to false, no metadata will be returned, and the data can be
+	// accessed as `k.String("key")`.
 	WithMeta bool
 }
 

--- a/providers/vault/vault.go
+++ b/providers/vault/vault.go
@@ -73,7 +73,8 @@ func (r *Vault) Read() (map[string]interface{}, error) {
 		s = secret.Data["data"].(map[string]interface{})
 	}
 
-	if !r.cfg.FlatPaths {
+	// Unflatten only when a delimiter is specified
+	if !r.cfg.FlatPaths && r.cfg.Delim != "" {
 		data := maps.Unflatten(s, r.cfg.Delim)
 
 		return data, nil


### PR DESCRIPTION
The `WithMeta` flag specifies whether the secret should be returned with its metadata. This is useful in most cases where the secret metadata is not required.

This also allows the secret to be read as `k.String("value")` instead of `k.String("data.value")`.

Also adds a check to `Unflatten` only when a delimiter is specified, preventing the issue which causes each character in the map key to be split by `.`, i.e. `data = {a = 1}` becomes `d.a.t.a = {a = 1}` after `Unflatten` with no delimiter specified.

fixes #218 