### PR TITLE
Fixed a nil panic issue in vault provider

### DIFF
--- a/providers/vault/go.mod
+++ b/providers/vault/go.mod
@@ -1,4 +1,4 @@
-module github.com/wangkang/koanf/providers/vault
+module github.com/knadh/koanf/providers/vault
 
 go 1.18
 

--- a/providers/vault/go.mod
+++ b/providers/vault/go.mod
@@ -1,4 +1,4 @@
-module github.com/knadh/koanf/providers/vault
+module github.com/wangkang/koanf/providers/vault
 
 go 1.18
 

--- a/providers/vault/vault.go
+++ b/providers/vault/vault.go
@@ -72,6 +72,10 @@ func (r *Vault) Read() (map[string]interface{}, error) {
 		return nil, err
 	}
 
+	if secret == nil {
+		return nil, errors.New("vault provider fetched no data")
+	}
+
 	s := secret.Data
 	if r.cfg.ExcludeMeta {
 		s = secret.Data["data"].(map[string]interface{})


### PR DESCRIPTION
If path does not exist in vault server, it return 404 status, then a panic will occur.