### PR TITLE
Add StrictUnmarshal to strictly match config fields and struct fields.

### DIFF
--- a/koanf.go
+++ b/koanf.go
@@ -244,6 +244,23 @@ func (ko *Koanf) Unmarshal(path string, o interface{}) error {
 	return ko.UnmarshalWithConf(path, o, UnmarshalConf{})
 }
 
+// StrictUnmarshal is like Unmarshal but enforces an exact one-to-one mapping between
+// the configuration and struct fields, ensuring that every field in the configuration
+// must have a corresponding field in the struct, and vice versa.
+func (ko *Koanf) StrictUnmarshal(path string, o interface{}) error {
+	return ko.UnmarshalWithConf(path, o, UnmarshalConf{
+		DecoderConfig: &mapstructure.DecoderConfig{
+			DecodeHook: mapstructure.ComposeDecodeHookFunc(
+				mapstructure.StringToTimeDurationHookFunc(),
+				textUnmarshalerHookFunc()),
+			Metadata:         nil,
+			Result:           o,
+			WeaklyTypedInput: true,
+			ErrorUnset:       true,
+			ErrorUnused:      true,
+		}})
+}
+
 // UnmarshalWithConf is like Unmarshal but takes configuration params in UnmarshalConf.
 // See mitchellh/mapstructure's DecoderConfig for advanced customization
 // of the unmarshal behaviour.


### PR DESCRIPTION
Please refer to #111 for context.
You can ensure that it is strictly unmarshaled into a struct by setting the ErrorUnset and ErrorUnused fields in the DecoderConfig.