### PR TITLE
Fix map unflattening no-delimiter behaviour

### DIFF
--- a/maps/maps.go
+++ b/maps/maps.go
@@ -74,9 +74,15 @@ func Unflatten(m map[string]interface{}, delim string) map[string]interface{} {
 	// Iterate through the flat conf map.
 	for k, v := range m {
 		var (
-			keys = strings.Split(k, delim)
+			keys []string
 			next = out
 		)
+
+		if delim != "" {
+			keys = strings.Split(k, delim)
+		} else {
+			keys = []string{k}
+		}
 
 		// Iterate through key parts, for eg:, parent.child.key
 		// will be ["parent", "child", "key"]

--- a/tests/maps_test.go
+++ b/tests/maps_test.go
@@ -101,7 +101,7 @@ var testMap3 = map[string]interface{}{
 }
 
 func TestFlatten(t *testing.T) {
-	f, k := maps.Flatten(testMap, nil, delim)
+	f, k := maps.Flatten(testMap, nil, ".")
 	assert.Equal(t, map[string]interface{}{
 		"parent.child.key":          123,
 		"parent.child.key.with.dot": 456,
@@ -118,17 +118,17 @@ func TestFlatten(t *testing.T) {
 
 func BenchmarkFlatten(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		maps.Flatten(testMap3, nil, delim)
+		maps.Flatten(testMap3, nil, ".")
 	}
 }
 
 func TestUnflatten(t *testing.T) {
-	m, _ := maps.Flatten(testMap, nil, delim)
-	um := maps.Unflatten(m, delim)
+	m, _ := maps.Flatten(testMap, nil, ".")
+	um := maps.Unflatten(m, ".")
 	assert.NotEqual(t, um, testMap)
 
-	m, _ = maps.Flatten(testMap2, nil, delim)
-	um = maps.Unflatten(m, delim)
+	m, _ = maps.Flatten(testMap2, nil, ".")
+	um = maps.Unflatten(m, ".")
 	assert.Equal(t, um, testMap2)
 }
 

--- a/tests/maps_test.go
+++ b/tests/maps_test.go
@@ -101,7 +101,7 @@ var testMap3 = map[string]interface{}{
 }
 
 func TestFlatten(t *testing.T) {
-	f, k := maps.Flatten(testMap, nil, ".")
+	f, k := maps.Flatten(testMap, nil, delim)
 	assert.Equal(t, map[string]interface{}{
 		"parent.child.key":          123,
 		"parent.child.key.with.dot": 456,
@@ -118,17 +118,17 @@ func TestFlatten(t *testing.T) {
 
 func BenchmarkFlatten(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		maps.Flatten(testMap3, nil, ".")
+		maps.Flatten(testMap3, nil, delim)
 	}
 }
 
 func TestUnflatten(t *testing.T) {
-	m, _ := maps.Flatten(testMap, nil, ".")
-	um := maps.Unflatten(m, ".")
+	m, _ := maps.Flatten(testMap, nil, delim)
+	um := maps.Unflatten(m, delim)
 	assert.NotEqual(t, um, testMap)
 
-	m, _ = maps.Flatten(testMap2, nil, ".")
-	um = maps.Unflatten(m, ".")
+	m, _ = maps.Flatten(testMap2, nil, delim)
+	um = maps.Unflatten(m, delim)
 	assert.Equal(t, um, testMap2)
 }
 


### PR DESCRIPTION
@rhnvrm please take a look at the commit that fixes the undefined variable `delim`. I'm wondering how all the tests were passing despite `maps_test.go` having a compile error. 

Closes #275