### PR TITLE
chore: Update godoc URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ koanf v2 has modules (Providers) for reading configuration from a variety of sou
 
 All external dependencies in providers and parsers are detached from the core and can be installed separately as necessary.
 
-[![Run Tests](https://github.com/knadh/koanf/actions/workflows/test.yml/badge.svg)](https://github.com/knadh/koanf/actions/workflows/test.yml) [![GoDoc](https://godoc.org/github.com/knadh/koanf?status.svg)](https://godoc.org/github.com/knadh/koanf) 
+[![Run Tests](https://github.com/knadh/koanf/actions/workflows/test.yml/badge.svg)](https://github.com/knadh/koanf/actions/workflows/test.yml) [![GoDoc](https://pkg.go.dev/badge/github.com/knadh/koanf?utm_source=godoc)](https://pkg.go.dev/github.com/knadh/koanf/v2) 
 
 ### Installation
 


### PR DESCRIPTION
The godoc link refers to the v1 koanf pkg. Updated it to use the new go.pkg URL and v2 koanf package.