### PR TITLE
Add Watch alternative to provider.File to return Watcher obj

### DIFF
--- a/providers/file/file.go
+++ b/providers/file/file.go
@@ -36,11 +36,16 @@ func (f *File) Read() (map[string]interface{}, error) {
 // Watch watches the file and triggers a callback when it changes. It is a
 // blocking function that internally spawns a goroutine to watch for changes.
 func (f *File) Watch(cb func(event interface{}, err error)) error {
+	_, err := f.WatchEx(cb)
+	return err
+}
+
+func (f *File) WatchEx(cb func(event interface{}, err error)) (*fsnotify.Watcher, error) {
 	// Resolve symlinks and save the original path so that changes to symlinks
 	// can be detected.
 	realPath, err := filepath.EvalSymlinks(f.path)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	realPath = filepath.Clean(realPath)
 
@@ -50,7 +55,7 @@ func (f *File) Watch(cb func(event interface{}, err error)) error {
 
 	w, err := fsnotify.NewWatcher()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var (
@@ -124,5 +129,5 @@ func (f *File) Watch(cb func(event interface{}, err error)) error {
 	}()
 
 	// Watch the directory for changes.
-	return w.Add(fDir)
+	return w, w.Add(fDir)
 }


### PR DESCRIPTION
This way the watcher object can be closed and deallocated properly.

The problem this solved, is when koanf is being used with managed dependency injection and the koanf instance is deallocated and reallocated at some time in the code. In these cases the created watchers are permanent, and koanf is still triggering the callbacks on obsolet koanf instances (which already belong to the GC).

We've found this during unit testing, where each test is bringing up its own config instance along with koanf, and watcher callbacks are being called after we have "deallocated" (removed the references to, as there's no Close() or anything similar on `koanf.Koanf`) to the koanf instance belonging to the test.
