### PR TITLE
fix(basicflag): option not apply

### DIFF
--- a/providers/basicflag/basicflag.go
+++ b/providers/basicflag/basicflag.go
@@ -66,11 +66,18 @@ func Provider(f *flag.FlagSet, delim string, opt ...*Opt) *Pflag {
 // function definition.
 // See https://github.com/knadh/koanf/issues/255
 func ProviderWithValue(f *flag.FlagSet, delim string, cb func(key string, value string) (string, interface{}), ko ...KoanfIntf) *Pflag {
-	return &Pflag{
+	pf := &Pflag{
 		flagset: f,
 		delim:   delim,
 		cb:      cb,
 	}
+
+	if len(ko) > 0 {
+		pf.opt = &Opt{
+			KeyMap: ko[0],
+		}
+	}
+	return pf
 }
 
 // Read reads the flag variables and returns a nested conf map.

--- a/tests/koanf_test.go
+++ b/tests/koanf_test.go
@@ -714,6 +714,30 @@ func TestFlags(t *testing.T) {
 		k := def.Copy()
 		bf := flag.NewFlagSet("test", flag.ContinueOnError)
 		bf.String("parent1.child1.type", "flag", "")
+		bf.String("parent2.child2.name", "override-default", "")
+		bf.Set("parent1.child1.type", "basicflag")
+		assert.Nil(k.Load(basicflag.ProviderWithValue(bf, ".",nil), nil), "error loading basicflag")
+		assert.Equal("basicflag", k.String("parent1.child1.type"), "types don't match")
+		assert.Equal("override-default", k.String("parent2.child2.name"), "basicflag default value override failed")
+	}
+
+	// No defualt-value override behaviour.
+	{
+		k := def.Copy()
+		bf := flag.NewFlagSet("test", flag.ContinueOnError)
+		bf.String("parent1.child1.name", "override-default", "")
+		bf.String("parent2.child2.name", "override-default", "")
+		bf.Set("parent2.child2.name", "custom")
+		assert.Nil(k.Load(basicflag.ProviderWithValue(bf, ".",nil, def),nil), "error loading basicflag")
+		assert.Equal("child1", k.String("parent1.child1.name"), "basicflag default overwrote")
+		assert.Equal("custom", k.String("parent2.child2.name"), "basicflag set failed")
+	}
+
+	// Override with the basicflag provider.
+	{
+		k := def.Copy()
+		bf := flag.NewFlagSet("test", flag.ContinueOnError)
+		bf.String("parent1.child1.type", "flag", "")
 		bf.Set("parent1.child1.type", "basicflag")
 		assert.Nil(k.Load(basicflag.Provider(bf, "."), nil), "error loading basicflag")
 		assert.Equal("basicflag", k.String("parent1.child1.type"), "types don't match")


### PR DESCRIPTION
`ProviderWithValue`  and `Provider` API not compatible, I can't reuse function. I have to copy test.

fix: https://github.com/knadh/koanf/issues/320

option1: make break change to api
option2: drop support for default vaule, no long need pass koanf instances. more like other providers.