### PR TITLE
chore: add a note about ignoring of non-exported fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,8 @@ func main() {
 	}
 
 	// Structure to unmarshal nested conf to.
+	// NOTE: only exported fields of a struct can be accessed, non exported 
+	// fields will be neglected.
 	type childStruct struct {
 		Name       string            `koanf:"name"`
 		Type       string            `koanf:"type"`
@@ -522,6 +524,8 @@ func main() {
 	// Load default values using the structs provider.
 	// We provide a struct along with the struct tag `koanf` to the
 	// provider.
+	// NOTE: only exported fields of a struct can be accessed, non exported 
+	// fields will be neglected.
 	k.Load(structs.Provider(sampleStruct{
 		Type:  "json",
 		Empty: make(map[string]string),

--- a/examples/read-struct/main.go
+++ b/examples/read-struct/main.go
@@ -49,6 +49,8 @@ func main() {
 		},
 	}
 
+	// NOTE: only exported fields of a struct can be accessed, non exported
+	// fields will be neglected.
 	k.Load(structs.Provider(s, "koanf"), nil)
 
 	fmt.Printf("name is = `%s`\n", k.String("parent1.child1.name"))

--- a/examples/unmarshal/main.go
+++ b/examples/unmarshal/main.go
@@ -22,6 +22,8 @@ func main() {
 	}
 
 	// Structure to unmarshal nested conf to.
+	// NOTE: only exported fields of a struct can be accessed, non exported
+	// fields will be neglected.
 	type childStruct struct {
 		Name       string            `koanf:"name"`
 		Type       string            `koanf:"type"`

--- a/koanf.go
+++ b/koanf.go
@@ -240,6 +240,9 @@ func (ko *Koanf) Marshal(p Parser) ([]byte, error) {
 // the mapstructure lib. If no path is specified, the whole map is unmarshalled.
 // `koanf` is the struct field tag used to match field names. To customize,
 // use UnmarshalWithConf(). It uses the mitchellh/mapstructure package.
+//
+// NOTE: only exported fields of a struct can be accessed, non exported
+// fields will be neglected.
 func (ko *Koanf) Unmarshal(path string, o interface{}) error {
 	return ko.UnmarshalWithConf(path, o, UnmarshalConf{})
 }
@@ -247,6 +250,9 @@ func (ko *Koanf) Unmarshal(path string, o interface{}) error {
 // UnmarshalWithConf is like Unmarshal but takes configuration params in UnmarshalConf.
 // See mitchellh/mapstructure's DecoderConfig for advanced customization
 // of the unmarshal behaviour.
+//
+// NOTE: only exported fields of a struct can be accessed, non exported
+// fields will be neglected.
 func (ko *Koanf) UnmarshalWithConf(path string, o interface{}, c UnmarshalConf) error {
 	if c.DecoderConfig == nil {
 		c.DecoderConfig = &mapstructure.DecoderConfig{

--- a/providers/structs/structs.go
+++ b/providers/structs/structs.go
@@ -19,6 +19,9 @@ type Structs struct {
 
 // Provider returns a provider that takes a takes a struct and a struct tag
 // and uses structs to parse and provide it to koanf.
+//
+// NOTE: only exported fields of a struct can be accessed, non exported
+// fields will be neglected.
 func Provider(s interface{}, tag string) *Structs {
 	return &Structs{s: s, tag: tag}
 }


### PR DESCRIPTION
Added a mention that you can't use non-exported fields with koanf.
It took me a while to figure out what I was doing wrong.