### PR TITLE
Update mapstructure to a stable version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,11 @@ module github.com/knadh/koanf/v2
 go 1.18
 
 require (
-	github.com/go-viper/mapstructure/v2 v2.0.0-alpha.1
+	github.com/go-viper/mapstructure/v2 v2.2.1
 	github.com/knadh/koanf/maps v0.1.1
 	github.com/mitchellh/copystructure v1.2.0
 )
 
 require github.com/mitchellh/reflectwalk v1.0.2 // indirect
 
-retract (
-	v2.0.2 // Tagged as minor version, but contains breaking changes.
-)
+retract v2.0.2 // Tagged as minor version, but contains breaking changes.

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/go-viper/mapstructure/v2 v2.0.0-alpha.1 h1:TQcrn6Wq+sKGkpyPvppOz99zsMBaUOKXq6HSv655U1c=
-github.com/go-viper/mapstructure/v2 v2.0.0-alpha.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=
+github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/knadh/koanf/maps v0.1.1 h1:G5TjmUh2D7G2YWf5SQQqSiHRJEjaicvU0KpypqB3NIs=
 github.com/knadh/koanf/maps v0.1.1/go.mod h1:npD/QZY3V6ghQDdcQzl1W4ICNVTkohC8E73eI2xW4yI=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=


### PR DESCRIPTION
Hey guys ✌️ 
I just got a recommendation to use this library.
While running `go get ...` I saw that it downloaded an `alpha` version of a dependency.
This felt a bit... awkward  😅 

So I updated `mapstructure` to more stable(?) version 🙃 