### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,16 +7,16 @@ jobs:
   test:
     strategy:
       matrix:
-        go: [ '1.18', '1.19', '1.20', '1.21' ]
+        go: [ '1.18', '1.19', '1.20', '1.21', '1.22', '1.23' ]
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     name: Go ${{ matrix.go }} Tests
     steps:
       - uses: actions/checkout@v4
  
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
           check-latest: true


### PR DESCRIPTION
* Testing more go versions
* Use latest ubuntu machine
* Update setup-go action

Just a small maintainance PR 🙃 

I guess setup-go is even a bit "critical" because github once announced to run only node20 actions.
See https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/