### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ returned as string slices or arrays. eg: `MYVAR_slice=a b c` becomes `slice: [a,
 ```go
 	k.Load(env.ProviderWithValue("MYVAR_", ".", func(s string, v string) (string, interface{}) {
 		// Strip out the MYVAR_ prefix and lowercase and get the key while also replacing
-		// the _ character with . in the key (koanf delimeter).
+		// the _ character with . in the key (koanf delimiter).
 		key := strings.Replace(strings.ToLower(strings.TrimPrefix(s, "MYVAR_")), "_", ".", -1)
 
 		// If there is a space in the value, split the value into a slice by the space.
@@ -660,7 +660,7 @@ Install with `go get -u github.com/knadh/koanf/providers/$provider`
 | ------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | file      | `file.Provider(filepath string)`                              | Reads a file and returns the raw bytes to be parsed.                                                                                                                                  |
 | fs      | `fs.Provider(f fs.FS, filepath string)`                              | (**Experimental**) Reads a file from fs.FS and returns the raw bytes to be parsed. The provider requires `go v1.16` or higher.                                            |
-| basicflag | `basicflag.Provider(f *flag.FlagSet, delim string)`           | Takes an stdlib `flag.FlagSet`                                                                                                                                                        |
+| basicflag | `basicflag.Provider(f *flag.FlagSet, delim string)`           | Takes a stdlib `flag.FlagSet`                                                                                                                                                        |
 | posflag   | `posflag.Provider(f *pflag.FlagSet, delim string)`            | Takes an `spf13/pflag.FlagSet` (advanced POSIX compatible flags with multiple types) and provides a nested config map based on delim.                                                 |
 | env       | `env.Provider(prefix, delim string, f func(s string) string)` | Takes an optional prefix to filter env variables by, an optional function that takes and returns a string to transform env variables, and returns a nested config map based on delim. |
 | confmap   | `confmap.Provider(mp map[string]interface{}, delim string)`   | Takes a premade `map[string]interface{}` conf map. If delim is provided, the keys are assumed to be flattened, thus unflattened using delim.                                          |
@@ -694,7 +694,7 @@ Install with `go get -u github.com/knadh/koanf/parsers/$parser`
 ### Third-party Providers
 | Package             | Provider                                                      | Description                                                                                                                                                                           |
 | ------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| github.com/defensestation/koanf/providers/secretsmanager     | `vault.SecretsMananger(secretsmanager.Config{}, f func(s string) string)`                              | AWS Secrets Manager provider, takes map or string as a value from store                                                						  |
+| github.com/defensestation/koanf/providers/secretsmanager     | `vault.SecretsManager(secretsmanager.Config{}, f func(s string) string)`                              | AWS Secrets Manager provider, takes map or string as a value from store                                                						  |
 | github.com/defensestation/koanf/providers/parameterstore     | `vault.ParameterStore(parameterstore.Config{}, f func(s string) string)`                              | AWS ParameterStore provider, an optional function that takes and returns a string to transform env variables                                                 						  |
 
 

--- a/examples/read-consul/koanfconsul.sh
+++ b/examples/read-consul/koanfconsul.sh
@@ -22,6 +22,6 @@ if [ $exitcode -eq 0 ]; then
 	echo -e "\nShutdown..."
 	consul leave
 else
-	echo "Consul server is inavailable."
+	echo "Consul server is unavailable."
 	consul leave
 fi

--- a/examples/read-consul/main.go
+++ b/examples/read-consul/main.go
@@ -175,7 +175,7 @@ func main() {
 	fmt.Printf("Second request test passed.\n")
 	kCheck.Delete("")
 
-	// adding metainformation: age (flags)
+	// adding metadata: age (flags)
 	newPair = &api.KVPair{Key: "parent1", Flags: uint64(42), Value: []byte("father")}
 	_, err = kv.Put(newPair, nil)
 	if err != nil {

--- a/examples/read-environment/main.go
+++ b/examples/read-environment/main.go
@@ -39,7 +39,7 @@ func main() {
 	// for example, turn space separated env vars into slices.
 	// k.Load(env.ProviderWithValue("MYVAR_", ".", func(s string, v string) (string, interface{}) {
 	// 	// Strip out the MYVAR_ prefix and lowercase and get the key while also replacing
-	// 	// the _ character with . in the key (koanf delimeter).
+	// 	// the _ character with . in the key (koanf delimiter).
 	// 	key := strings.Replace(strings.ToLower(strings.TrimPrefix(s, "MYVAR_")), "_", ".", -1)
 
 	// 	// If there is a space in the value, split the value into a slice by the space.

--- a/examples/unmarshal/main.go
+++ b/examples/unmarshal/main.go
@@ -44,7 +44,7 @@ func main() {
 	fmt.Println(out)
 
 	// Marshal the instance back to JSON.
-	// The paser instance can be anything, eg: json.Paser(),
+	// The parser instance can be anything, eg: json.Parser(),
 	// yaml.Parser() etc.
 	b, _ := k.Marshal(parser)
 	fmt.Println(string(b))

--- a/parsers/hcl/hcl_test.go
+++ b/parsers/hcl/hcl_test.go
@@ -19,7 +19,7 @@ func TestHCL_Unmarshal(t *testing.T) {
 		function HCL
 	}{
 		{
-			name:     "Empty HCL - With faltten",
+			name:     "Empty HCL - With flatten",
 			input:    []byte(`{}`),
 			function: *hclParserWithFlatten,
 			output:   map[string]interface{}{},
@@ -31,7 +31,7 @@ func TestHCL_Unmarshal(t *testing.T) {
 			output:   map[string]interface{}{},
 		},
 		{
-			name: "Valid HCL - With faltten",
+			name: "Valid HCL - With flatten",
 			input: []byte(`resource "aws_instance" "example" {
 				count = 2 # meta-argument first
 				ami           = "abc123"
@@ -57,7 +57,7 @@ func TestHCL_Unmarshal(t *testing.T) {
 			},
 		},
 		{
-			name: "Valid HCL - Without faltten",
+			name: "Valid HCL - Without flatten",
 			input: []byte(`resource "aws_instance" "example" {
 				count = 2 # meta-argument first
 				ami           = "abc123"

--- a/parsers/yaml/yaml_test.go
+++ b/parsers/yaml/yaml_test.go
@@ -28,7 +28,7 @@ number: 2`),
 			values: []interface{}{"val", "test", 2},
 		},
 		{
-			name: "Invalid YAML - wrong intendation",
+			name: "Invalid YAML - wrong indentation",
 			input: []byte(`key: val
 			name: test
 			number: 2`),

--- a/providers/appconfig/appconfig.go
+++ b/providers/appconfig/appconfig.go
@@ -50,7 +50,7 @@ type Config struct {
 	// The AWS IAM Role ARN to use. Useful for access requiring IAM AssumeRole.
 	AWSRoleARN string
 
-	// The AWS Region to use. This value is fetched from teh environment if not specified.
+	// The AWS Region to use. This value is fetched from the environment if not specified.
 	AWSRegion string
 
 	// Time interval at which the watcher will refresh the configuration.
@@ -143,7 +143,7 @@ func (ac *AppConfig) Watch(cb func(event interface{}, err error)) error {
 				break loop
 			}
 
-			// Check if the the configuration has been updated.
+			// Check if the configuration has been updated.
 			if len(conf.Content) == 0 {
 				// Configuration is not updated and we have the latest version.
 				// Sleep for WatchInterval and retry watcher.

--- a/providers/basicflag/basicflag.go
+++ b/providers/basicflag/basicflag.go
@@ -57,7 +57,7 @@ func Provider(f *flag.FlagSet, delim string, opt ...*Opt) *Pflag {
 // to modify both. This is useful for cases where you may want to return
 // other types like a string slice instead of just a string.
 //
-// It takes an optional Opt{} (but recommended) argument with a Koanf instance (opt.KeyMap) to see if the
+// It takes an optional Opt{} (but recommended) argument with a Koanf instance (opt.KeyMap) to see if
 // the flags defined have been set from other providers, for instance,
 // a config file. If they are not, then the default values of the flags
 // are merged. If they do exist, the flag values are not merged but only

--- a/providers/confmap/confmap.go
+++ b/providers/confmap/confmap.go
@@ -16,7 +16,7 @@ type Confmap struct {
 
 // Provider returns a confmap Provider that takes a flat or nested
 // map[string]interface{}. If a delim is provided, it indicates that the
-// keys are flat and the map needs to be unflatted by delim.
+// keys are flat and the map needs to be unflattened by delim.
 func Provider(mp map[string]interface{}, delim string) *Confmap {
 	cp := maps.Copy(mp)
 	maps.IntfaceKeysToStrings(cp)

--- a/providers/parameterstore/parameterstore.go
+++ b/providers/parameterstore/parameterstore.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Input is a constraint that permits any input type
-// to get paramers from AWS Systems Manager Parameter Store.
+// to get parameters from AWS Systems Manager Parameter Store.
 type Input interface {
 	ssm.GetParameterInput | ssm.GetParametersInput | ssm.GetParametersByPathInput
 }

--- a/providers/posflag/posflag.go
+++ b/providers/posflag/posflag.go
@@ -32,7 +32,7 @@ type Posflag struct {
 // delim "." will convert the key `parent.child.key: 1`
 // to `{parent: {child: {key: 1}}}`.
 //
-// It takes an optional (but recommended) Koanf instance to see if the
+// It takes an optional (but recommended) Koanf instance to see if
 // the flags defined have been set from other providers, for instance,
 // a config file. If they are not, then the default values of the flags
 // are merged. If they do exist, the flag values are not merged but only
@@ -62,7 +62,7 @@ func ProviderWithValue(f *pflag.FlagSet, delim string, ko KoanfIntf, cb func(key
 // ProviderWithFlag takes pflag.FlagSet and a callback that takes *pflag.Flag
 // and applies the callback to all items in the flagset. It does not parse
 // pflag.Flag values and expects the callback to process the keys and values
-// from *pflag.Flag however. FlagVal() can be used in the callbakc to avoid
+// from *pflag.Flag however. FlagVal() can be used in the callback to avoid
 // repeating the type-switch block for parsing values.
 // Returning "" for the key causes the particular flag to be disregarded.
 //

--- a/providers/structs/structs.go
+++ b/providers/structs/structs.go
@@ -17,7 +17,7 @@ type Structs struct {
 	delim string
 }
 
-// Provider returns a provider that takes a takes a struct and a struct tag
+// Provider returns a provider that takes a struct and a struct tag
 // and uses structs to parse and provide it to koanf.
 func Provider(s interface{}, tag string) *Structs {
 	return &Structs{s: s, tag: tag}

--- a/tests/fs_test.go
+++ b/tests/fs_test.go
@@ -27,7 +27,7 @@ func TestFSProvider(t *testing.T) {
 	testFS := os.DirFS("../mock")
 
 	for _, c := range cases {
-		// Test fs.FS before setting up kaonf
+		// Test fs.FS before setting up koanf
 		err := fstest.TestFS(testFS, c.file)
 		require.NoError(t, err, "failed asserting file existence in fs.FS")
 

--- a/tests/koanf_test.go
+++ b/tests/koanf_test.go
@@ -527,7 +527,7 @@ func TestWatchFileSymlink(t *testing.T) {
 	// Create a temp symlink to the YAML file and rename the old symlink to the new
 	// symlink. We do this to avoid removing the symlink and triggering a REMOVE event.
 	time.Sleep(1 * time.Second)
-	assert.NoError(os.Rename(symPath2, symPath), "error swaping symlink to another file type")
+	assert.NoError(os.Rename(symPath2, symPath), "error swapping symlink to another file type")
 	if waitTimeout(&wg, time.Second*10) {
 		assert.Fail("timeout waiting for file watch trigger")
 	} else {
@@ -648,7 +648,7 @@ func TestUnwatchFile(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 	assert.True(reloaded, "watched file didn't reload")
 
-	// Unwatch the file and verify that the watch didn't triger.
+	// Unwatch the file and verify that the watch didn't trigger.
 	assert.NoError(f.Unwatch())
 	reloaded = false
 	time.Sleep(100 * time.Millisecond)
@@ -739,7 +739,7 @@ func TestFlags(t *testing.T) {
 	// Key that doesn't exist in the loaded file conf. Should merge the default value.
 	f.String("flagkey", "flag", "")
 
-	// Key that exists in the loadd conf but no Set(). Default value shouldn't be merged.
+	// Key that exists in the loaded conf but no Set(). Default value shouldn't be merged.
 	f.String("parent1.name", "flag", "")
 
 	// Initialize the provider with the Koanf instance passed where default values
@@ -784,7 +784,7 @@ func TestFlags(t *testing.T) {
 		assert.Equal("override-default", k.String("parent2.child2.name"), "basicflag default value override failed")
 	}
 
-	// No defualt-value override behaviour.
+	// No default-value override behaviour.
 	{
 		k := def.Copy()
 		bf := flag.NewFlagSet("test", flag.ContinueOnError)
@@ -808,7 +808,7 @@ func TestFlags(t *testing.T) {
 		assert.Equal("override-default", k.String("parent2.child2.name"), "basicflag default value override failed")
 	}
 
-	// No defualt-value override behaviour.
+	// No default-value override behaviour.
 	{
 		k := def.Copy()
 		bf := flag.NewFlagSet("test", flag.ContinueOnError)
@@ -1171,7 +1171,7 @@ func TestUnmarshalCustomText(t *testing.T) {
 	}{}
 
 	// Test custom unmarshalling of strings via mapstructure's UnmarshalText()
-	// methods. customText is a int type that strips of the `mb` suffix and parses
+	// methods. customText is an int type that strips of the `mb` suffix and parses
 	// the rest into a number.
 
 	k := koanf.New(delim)


### PR DESCRIPTION
Fixed a few typos I stumbled on.

- callbakc
- defualt
- delimeter
- faltten
- inavailable
- intendation
- kaonf
- loadd
- mananger
- metainformation
- paramers
- paser
- swaping
- teh
- triger
- unflatted