### PR TITLE
add toggle to split nats kv on "." delimiter

### DIFF
--- a/providers/nats/nats.go
+++ b/providers/nats/nats.go
@@ -26,7 +26,9 @@ type Config struct {
 	// Prefix (optional).
 	Prefix string
 
-	// If delim is true, keys will be split by the NATS KV "." delimiter ()
+	// If true, keys will be split by delimiter "." into a nested map
+	// So, "a.b.c" results in {"a": {"b": {"c": "value" }}}
+	// Prefix will be included
 	Split bool
 }
 

--- a/providers/nats/nats.go
+++ b/providers/nats/nats.go
@@ -26,10 +26,10 @@ type Config struct {
 	// Prefix (optional).
 	Prefix string
 
-	// If true, keys will be split by delimiter "." into a nested map
+	// If true, keys will be unflattened by delimiter "." into a nested map
 	// So, "a.b.c" results in {"a": {"b": {"c": "value" }}}
 	// Prefix will be included
-	Split bool
+	Unflatten bool
 }
 
 // Nats implements the nats config provider.
@@ -81,7 +81,7 @@ func (n *Nats) Read() (map[string]interface{}, error) {
 		}
 		mp[res.Key()] = string(res.Value())
 	}
-	if n.cfg.Split {
+	if n.cfg.Unflatten {
 		return maps.Unflatten(mp, "."), nil
 	}
 

--- a/providers/nats/nats.go
+++ b/providers/nats/nats.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/knadh/koanf/maps"
 	"github.com/nats-io/nats.go"
 )
 
@@ -24,6 +25,9 @@ type Config struct {
 
 	// Prefix (optional).
 	Prefix string
+
+	// If delim is true, keys will be split by the NATS KV "." delimiter ()
+	Split bool
 }
 
 // Nats implements the nats config provider.
@@ -74,6 +78,9 @@ func (n *Nats) Read() (map[string]interface{}, error) {
 			return nil, err
 		}
 		mp[res.Key()] = string(res.Value())
+	}
+	if n.cfg.Split {
+		return maps.Unflatten(mp, "."), nil
 	}
 
 	return mp, nil


### PR DESCRIPTION
This adds an optional "split" boolean config field to allow for splitting/unflattening a natskv key on the "." delimiter that denotes NATS KV subject/key hierarchies  

My use case is:

Prefix = "abc"
There's a key "abc.xyz" with a value of "123"

Currently it will filter for keys with the "abc" prefix (minimizing kv.Get() calls), but then it just ends up setting `{ "abc.xyz" : 123 }` in the koanf confmap.

This PR allows it to split the key so that the conf map gets updated with something like this (or whatever the proper nested map syntax is in go)

```
{
  "abc": {
    "xyz": 123
  }
}
```

Inspiration taken from the [env provider](https://github.com/knadh/koanf/blob/de8b5dfc5667a3329688cd269f6a788389e16cdf/providers/env/env.go#L97) (and surely many others do something similar)

I'm quite open to renaming the field to something other than Split, as well as changing its comment description