### PR TITLE
Fix rendering of header and add it to the table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ go get -u github.com/knadh/koanf/parsers/toml
 - [Watching file for changes](#watching-file-for-changes)
 - [Reading from command line](#reading-from-command-line)
 - [Reading environment variables](#reading-environment-variables)
+- [Reading from an S3 bucket](#reading-from-an-s3-bucket)
 - [Reading raw bytes](#reading-raw-bytes)
 - [Reading from maps and structs](#reading-from-nested-maps)
 - [Unmarshalling and marshalling](#unmarshalling-and-marshalling)
@@ -269,8 +270,8 @@ func main() {
 	fmt.Println("name is =", k.String("parent1.child1.name"))
 	fmt.Println("time is =", k.Time("time", time.DateOnly))
 	fmt.Println("ids are =", k.Strings("parent1.child1.grandchild1.ids"))
-}```
-
+}
+```
 
 ### Reading from an S3 bucket
 


### PR DESCRIPTION
The heading `### Reading from an S3 bucket` is not being rendered like it should due to a misplaced code fence end tag in the previous section. Also, the section was not listed in the table of contents. This PR fixes that.