### PR TITLE
providers/cliflagv3: Set the flags if they have a default value

### DIFF
--- a/providers/cliflagv3/cliflagv3.go
+++ b/providers/cliflagv3/cliflagv3.go
@@ -79,7 +79,7 @@ func (p *CliFlag) Read() (map[string]interface{}, error) {
 func (p *CliFlag) processFlags(flags []cli.Flag, prefix string, out map[string]interface{}) {
 	for _, flag := range flags {
 		name := flag.Names()[0]
-		if p.cmd.IsSet(name) || slices.Contains(p.config.Defaults, name) {
+		if p.cmd.IsSet(name) || slices.Contains(p.config.Defaults, name) || p.cmd.Value(name) != nil {
 			value := p.getFlagValue(name)
 			if value != nil {
 				// Build the full path for the flag


### PR DESCRIPTION
Before those needed to be manually set with '--flag-name' or with the 'Config' whic is really anoying to do. So now flags with 'Value'(default) will be also by default set to the output. It should be the 'default' behavior