### PR TITLE
fix: preserve nil pointer types in Get() method

### DIFF
--- a/koanf.go
+++ b/koanf.go
@@ -357,7 +357,7 @@ func (ko *Koanf) Get(path string) any {
 
 	// Skil nil pointers before copying.
 	if rv := reflect.ValueOf(res); rv.Kind() == reflect.Ptr && rv.IsNil() {
-		return nil
+		return res
 	}
 
 	out, _ := copystructure.Copy(&res)

--- a/tests/koanf_test.go
+++ b/tests/koanf_test.go
@@ -2058,7 +2058,10 @@ func TestGetNilPointer(t *testing.T) {
 	var nt *test
 	assert.Nil(k.Set("key", nt))
 	assert.True(k.Exists("key"))
-	assert.Nil(k.Get("key"))
+	got := k.Get("key")
+	assert.Nil(got)
+	_, ok := got.(*test)
+	assert.True(ok, "expected type *test, got %T", got)
 
 	// Test nil value.
 	assert.Nil(k.Set("val", nil))
@@ -2067,5 +2070,8 @@ func TestGetNilPointer(t *testing.T) {
 	// Test slice.
 	var s *[]string
 	assert.Nil(k.Set("slice", s))
-	assert.Nil(k.Get("slice"))
+	gotSlice := k.Get("slice")
+	assert.Nil(gotSlice)
+	_, ok = gotSlice.(*[]string)
+	assert.True(ok, "expected type *[]string, got %T", gotSlice)
 }


### PR DESCRIPTION
- Changed Get() to return the original nil pointer value instead of untyped nil, preserving the pointer's type information
- Added type assertions in TestGetNilPointer to verify the returned nil values maintain their original types (*test, *[]string)