### PR TITLE
fix: hold RLock during copy in Get to prevent concurrent map access

### DIFF
--- a/koanf.go
+++ b/koanf.go
@@ -334,13 +334,13 @@ func (ko *Koanf) Get(path string) any {
 
 	// Does the path exist?
 	ko.mu.RLock()
+	defer ko.mu.RUnlock()
+
 	p, ok := ko.keyMap[path]
 	if !ok {
-		ko.mu.RUnlock()
 		return nil
 	}
 	res := maps.Search(ko.confMap, p)
-	ko.mu.RUnlock()
 
 	// Non-reference types are okay to return directly.
 	// Other types are "copied" with maps.Copy or json.Marshal
@@ -355,7 +355,7 @@ func (ko *Koanf) Get(path string) any {
 		return nil
 	}
 
-	// Skil nil pointers before copying.
+	// Skip nil pointers before copying.
 	if rv := reflect.ValueOf(res); rv.Kind() == reflect.Ptr && rv.IsNil() {
 		return res
 	}


### PR DESCRIPTION
## Summary

- Fixes a race condition in `Get()` where the `RLock` was released before `maps.Copy()` and `copystructure.Copy()` operated on reference types (maps, slices, etc.), allowing concurrent writes to cause `fatal error: concurrent map read and map write` panics.
- Uses `defer ko.mu.RUnlock()` so the read lock is held for the entire duration of the copy operations, matching the pattern already used by `All()` and `Raw()`.
- Also fixes a minor typo in a comment ("Skil" -> "Skip").

## Details

The `Get` method previously did:
```go
ko.mu.RLock()
res := maps.Search(ko.confMap, p)
ko.mu.RUnlock()       // <-- lock released here
// ...
maps.Copy(v)          // <-- iterates map without lock protection
copystructure.Copy()  // <-- same issue
```

This created a window where a concurrent `Load`/`Set`/`Delete` could modify the underlying map while `Copy` was iterating it. The fix changes to `defer ko.mu.RUnlock()` so the lock covers the copy operations.

Fixes #401

## Test plan

- [x] `go vet ./...` passes
- [x] `go build ./...` passes
- [x] Existing tests pass
- The race condition requires `go test -race` with CGO enabled to reproduce reliably

🤖 Generated with [Claude Code](https://claude.com/claude-code)