### PR TITLE
Bools: return the matched []bool, not the nil intermediate

### DIFF
--- a/getters.go
+++ b/getters.go
@@ -589,7 +589,7 @@ func (ko *Koanf) Bools(path string) []bool {
 		}
 		return out
 	case []bool:
-		return out
+		return v
 	}
 	return nil
 }

--- a/tests/koanf_test.go
+++ b/tests/koanf_test.go
@@ -1526,6 +1526,17 @@ func TestGetStringsMap(t *testing.T) {
 	assert.Equal(map[string][]string{"k2": {"value"}}, k.StringsMap("ifaces3"), "types don't match")
 }
 
+func TestBoolsNativeSlice(t *testing.T) {
+	assert := assert.New(t)
+
+	k := koanf.New(delim)
+	assert.NoError(k.Load(confmap.Provider(map[string]any{
+		"bools": []bool{true, false, true},
+	}, "."), nil))
+
+	assert.Equal([]bool{true, false, true}, k.Bools("bools"))
+}
+
 // waitTimeout waits for the waitgroup for the specified max timeout.
 // Returns true if waiting timed out.
 func waitTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {


### PR DESCRIPTION
Spotted while reading getters.go. The Bools() type switch has

    case []bool:
        return out

but `out` is the `var out []bool` declared above and only filled by the `[]any` branch, so on a value stored natively as a `[]bool` (e.g. via the confmap provider) Bools() returns nil. Mirrors what Ints, Int64s, and Float64s already do for their native-type cases (they return `v`).

Added a tiny regression test in koanf_test.go using the confmap provider; it fails on master with `<nil>` vs the expected `[]bool{true, false, true}`.