### PR TITLE
fix: report the full key path in MergeStrict type-mismatch error

### DIFF
--- a/maps/maps.go
+++ b/maps/maps.go
@@ -169,7 +169,7 @@ func mergeStrict(a, b map[string]any, fullKey string) error {
 			if reflect.TypeOf(b[key]) == reflect.TypeOf(val) {
 				b[key] = val
 			} else {
-				return fmt.Errorf("incorrect types at key %v, type %T != %T", fullKey, b[key], val)
+				return fmt.Errorf("incorrect types at key %v, type %T != %T", newFullKey, b[key], val)
 			}
 			continue
 		}

--- a/tests/maps_test.go
+++ b/tests/maps_test.go
@@ -266,6 +266,28 @@ func TestMergeStrict(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestMergeStrictErrorKey(t *testing.T) {
+	// The type-mismatch error must name the full path to the conflicting key,
+	// including the leaf. Previously it reported the parent path, which left
+	// the key blank for a top-level conflict and dropped the leaf for nested
+	// ones.
+	err := maps.MergeStrict(
+		map[string]any{"key": "string"},
+		map[string]any{"key": 1},
+	)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "incorrect types at key key,")
+	}
+
+	err = maps.MergeStrict(
+		map[string]any{"parent": map[string]any{"child": map[string]any{"key": "string"}}},
+		map[string]any{"parent": map[string]any{"child": map[string]any{"key": 1}}},
+	)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "incorrect types at key parent.child.key,")
+	}
+}
+
 func TestMapDelete(t *testing.T) {
 	testMap := map[string]any{
 		"parent": map[string]any{


### PR DESCRIPTION
`mergeStrict` (`maps/maps.go`) builds `newFullKey`, the full dotted path to the key currently being merged, and passes it to the recursive call. But the type-mismatch error reports the parent `fullKey` instead:

```go
return fmt.Errorf("incorrect types at key %v, type %T != %T", fullKey, b[key], val)
```

So the error names the wrong key:

- A **top-level** type conflict has `fullKey == ""`, producing `incorrect types at key , type int != string` (blank key name).
- A **nested** conflict reports the enclosing map path and drops the actual conflicting leaf, e.g. `parent.child` instead of `parent.child.key`.

This is reachable from public API via `MergeStrict` and `Koanf.Load` with `Conf{StrictMerge: true}`. The fix uses `newFullKey`, matching what the recursive call already uses.

Added `TestMergeStrictErrorKey` in `tests/maps_test.go` asserting the error names the full path for both a top-level and a nested conflict (the existing `TestMergeStrict` only checked that an error occurred, not its contents). `go test` passes.
