### PR TITLE
deps: upgrade go-toml to v2.4.3

### DIFF
--- a/parsers/toml/go.mod
+++ b/parsers/toml/go.mod
@@ -3,7 +3,7 @@ module github.com/knadh/koanf/parsers/toml/v2
 go 1.23.0
 
 require (
-	github.com/pelletier/go-toml/v2 v2.3.1
+	github.com/pelletier/go-toml/v2 v2.4.0
 	github.com/stretchr/testify v1.9.0
 )
 

--- a/parsers/toml/go.mod
+++ b/parsers/toml/go.mod
@@ -3,7 +3,7 @@ module github.com/knadh/koanf/parsers/toml/v2
 go 1.23.0
 
 require (
-	github.com/pelletier/go-toml/v2 v2.4.0
+	github.com/pelletier/go-toml/v2 v2.4.2
 	github.com/stretchr/testify v1.9.0
 )
 

--- a/parsers/toml/go.mod
+++ b/parsers/toml/go.mod
@@ -3,7 +3,7 @@ module github.com/knadh/koanf/parsers/toml/v2
 go 1.23.0
 
 require (
-	github.com/pelletier/go-toml/v2 v2.4.2
+	github.com/pelletier/go-toml/v2 v2.4.3
 	github.com/stretchr/testify v1.9.0
 )
 

--- a/parsers/toml/go.sum
+++ b/parsers/toml/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7olPtrEc=
-github.com/pelletier/go-toml/v2 v2.3.1/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
+github.com/pelletier/go-toml/v2 v2.4.0 h1:Mwu0mAkUKbittDs3/ADDWXqMmq3EOK2VHiuCkV00Row=
+github.com/pelletier/go-toml/v2 v2.4.0/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=

--- a/parsers/toml/go.sum
+++ b/parsers/toml/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pelletier/go-toml/v2 v2.4.2 h1:M2fKKbmyvI+hGId/D0W64qDBMVhJnNR10O5gIbMc//Q=
-github.com/pelletier/go-toml/v2 v2.4.2/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
+github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdDPYVpY=
+github.com/pelletier/go-toml/v2 v2.4.3/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=

--- a/parsers/toml/go.sum
+++ b/parsers/toml/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pelletier/go-toml/v2 v2.4.0 h1:Mwu0mAkUKbittDs3/ADDWXqMmq3EOK2VHiuCkV00Row=
-github.com/pelletier/go-toml/v2 v2.4.0/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
+github.com/pelletier/go-toml/v2 v2.4.2 h1:M2fKKbmyvI+hGId/D0W64qDBMVhJnNR10O5gIbMc//Q=
+github.com/pelletier/go-toml/v2 v2.4.2/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=

--- a/parsers/toml/toml.go
+++ b/parsers/toml/toml.go
@@ -21,11 +21,19 @@ func (p *TOML) Unmarshal(b []byte) (map[string]any, error) {
 		return nil, err
 	}
 
+	if len(outMap) == 0 {
+		return nil, nil
+	}
+
 	return outMap, nil
 }
 
 // Marshal marshals the given config map to TOML bytes.
 func (p *TOML) Marshal(o map[string]any) ([]byte, error) {
+	if len(o) == 0 {
+		return nil, nil
+	}
+
 	out, err := toml.Marshal(&o)
 	if err != nil {
 		return nil, err

--- a/parsers/toml/toml_test.go
+++ b/parsers/toml/toml_test.go
@@ -16,7 +16,7 @@ func TestTOML_Unmarshal(t *testing.T) {
 		{
 			name:   "Empty TOML",
 			input:  []byte(``),
-			output: map[string]any{},
+			output: map[string]any(nil),
 		},
 		{
 			name: "Valid TOML",
@@ -86,7 +86,7 @@ func TestTOML_Marshal(t *testing.T) {
 		{
 			name:   "Empty TOML",
 			input:  map[string]any{},
-			output: []byte{},
+			output: []byte(nil),
 		},
 		{
 			name: "Valid TOML",

--- a/parsers/toml/toml_test.go
+++ b/parsers/toml/toml_test.go
@@ -16,7 +16,7 @@ func TestTOML_Unmarshal(t *testing.T) {
 		{
 			name:   "Empty TOML",
 			input:  []byte(``),
-			output: map[string]any(nil),
+			output: map[string]any{},
 		},
 		{
 			name: "Valid TOML",
@@ -86,7 +86,7 @@ func TestTOML_Marshal(t *testing.T) {
 		{
 			name:   "Empty TOML",
 			input:  map[string]any{},
-			output: []byte(nil),
+			output: []byte{},
 		},
 		{
 			name: "Valid TOML",


### PR DESCRIPTION
https://github.com/pelletier/go-toml/releases/tag/v2.4.3