### PR TITLE
fix: error on scalar/map type mismatch in MergeStrict regardless of order

### DIFF
--- a/maps/maps.go
+++ b/maps/maps.go
@@ -181,7 +181,9 @@ func mergeStrict(a, b map[string]any, fullKey string) error {
 				return err
 			}
 		default:
-			b[key] = val
+			// The incoming value is a map but the target value is not,
+			// which is a type mismatch.
+			return fmt.Errorf("incorrect types at key %v, type %T != %T", newFullKey, b[key], val)
 		}
 	}
 	return nil

--- a/tests/maps_test.go
+++ b/tests/maps_test.go
@@ -288,6 +288,30 @@ func TestMergeStrictErrorKey(t *testing.T) {
 	}
 }
 
+func TestMergeStrictScalarVsMap(t *testing.T) {
+	// A type mismatch must be reported regardless of which side is the map.
+	// Previously, a scalar in the target overwritten by an incoming map was
+	// silently accepted, while the reverse (map overwritten by a scalar) errored.
+
+	// Incoming map over an existing scalar must error.
+	err := maps.MergeStrict(
+		map[string]any{"key": map[string]any{"child": 2}},
+		map[string]any{"key": 1},
+	)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "incorrect types at key key,")
+	}
+
+	// Incoming scalar over an existing map must error (existing behaviour).
+	err = maps.MergeStrict(
+		map[string]any{"key": 1},
+		map[string]any{"key": map[string]any{"child": 2}},
+	)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "incorrect types at key key,")
+	}
+}
+
 func TestMapDelete(t *testing.T) {
 	testMap := map[string]any{
 		"parent": map[string]any{


### PR DESCRIPTION
`StrictMerge` only reported a type mismatch when an existing map was replaced by a scalar, but silently accepted the reverse - a scalar replaced by a map - so whether a genuine conflict was caught depended on file load order. This makes the map-incoming branch return the same `incorrect types at key ...` error as the scalar-incoming branch.
