### PR TITLE
fix: correct "usecase" typo to "use cases" in provider comments

### DIFF
--- a/providers/env/env.go
+++ b/providers/env/env.go
@@ -27,7 +27,7 @@ type Opt struct {
 	// TransformFunc is an optional callback that takes an environment
 	// variable's string name and value, runs arbitrary transformations
 	// on them and returns a transformed string key and value of any type.
-	// Common usecase are stripping prefixes from keys, lowercasing variable names,
+	// Common use cases are stripping prefixes from keys, lowercasing variable names,
 	// replacing _ with . etc. Eg: APP_DB_HOST -> db.host
 	// If the returned variable name is an empty string (""), it is ignored altogether.
 	TransformFunc func(k, v string) (string, any)

--- a/providers/k8smount/provider.go
+++ b/providers/k8smount/provider.go
@@ -45,7 +45,7 @@ var _ koanf.Provider = (*K8SMount)(nil)
 type Opt struct {
 	// TransformFunc is an optional callback that takes a volume mount field's name and value, runs
 	// arbitrary transformations on them and returns a transformed string key and value of any type.
-	// Common usecase are lowercasing keys, replacing _ with . etc. For example, DB_HOST -> db.host.
+	// Common use cases are lowercasing keys, replacing _ with . etc. For example, DB_HOST -> db.host.
 	// If the returned key is an empty string (""), it is ignored altogether.
 	TransformFunc func(k, v string) (string, any)
 }

--- a/providers/kiln/kiln.go
+++ b/providers/kiln/kiln.go
@@ -27,7 +27,7 @@ type Opt struct {
 	// TransformFunc is an optional callback that takes an environment
 	// variable's string name and value, runs arbitrary transformations
 	// on them and returns a transformed string key and value of any type.
-	// Common usecase are stripping prefixes from keys, lowercasing variable names,
+	// Common use cases are stripping prefixes from keys, lowercasing variable names,
 	// replacing _ with . etc. Eg: APP_DB_HOST -> db.host
 	// If the returned variable name is an empty string (""), it is ignored altogether.
 	TransformFunc func(k, v string) (string, any)


### PR DESCRIPTION
## Summary

Three providers had the same grammatical error in their `TransformFunc` godoc comment: `"Common usecase are"`. `usecase` is not a standard English word (it should be two words: `use case`), and the verb must agree with the plural noun.

Affected files:
- `providers/env/env.go`
- `providers/kiln/kiln.go`
- `providers/k8smount/provider.go`

All three had identical copy-pasted comment text with the same error.

## Changes

```
- // Common usecase are stripping prefixes from keys, ...
+ // Common use cases are stripping prefixes from keys, ...
```

No logic changes — godoc comment fix only.