### PR TITLE
Handle unsigned integers in toInt64 without precision loss

### DIFF
--- a/koanf.go
+++ b/koanf.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding"
 	"fmt"
+	"math"
 	"reflect"
 	"sort"
 	"strconv"
@@ -483,6 +484,16 @@ func toInt64(v any) (int64, error) {
 		return int64(i), nil
 	case int64:
 		return i, nil
+	case uint:
+		return uintToInt64(uint64(i))
+	case uint8:
+		return int64(i), nil
+	case uint16:
+		return int64(i), nil
+	case uint32:
+		return int64(i), nil
+	case uint64:
+		return uintToInt64(i)
 	}
 
 	// Force it to a string and try to convert.
@@ -492,6 +503,16 @@ func toInt64(v any) (int64, error) {
 	}
 
 	return int64(f), nil
+}
+
+// uintToInt64 converts an unsigned integer to int64, returning an error if the
+// value overflows int64 rather than silently losing precision via a float64
+// round-trip.
+func uintToInt64(v uint64) (int64, error) {
+	if v > math.MaxInt64 {
+		return 0, fmt.Errorf("value %d overflows int64", v)
+	}
+	return int64(v), nil
 }
 
 // toInt64 takes a `v any` value and if it is a float type,

--- a/tests/koanf_test.go
+++ b/tests/koanf_test.go
@@ -2108,3 +2108,16 @@ func TestGetNilPointer(t *testing.T) {
 	_, ok = gotSlice.(*[]string)
 	assert.True(ok, "expected type *[]string, got %T", gotSlice)
 }
+
+func TestInt64UnsignedPrecision(t *testing.T) {
+	// Unsigned integers above 2^53 must not lose precision through a float64
+	// round-trip in toInt64.
+	k := koanf.New(delim)
+	err := k.Load(confmap.Provider(map[string]interface{}{
+		"u":   uint(9007199254740993),
+		"u64": uint64(9007199254740993),
+	}, delim), nil)
+	assert.Nil(t, err)
+	assert.Equal(t, int64(9007199254740993), k.Int64("u"))
+	assert.Equal(t, int64(9007199254740993), k.Int64("u64"))
+}


### PR DESCRIPTION
### Problem

`toInt64`'s type switch only handles the signed integer types (`int`, `int8`, `int16`, `int32`, `int64`). Unsigned values (`uint`, `uint8`, `uint16`, `uint32`, `uint64`) fall through to the fallback:

```go
f, err := strconv.ParseFloat(fmt.Sprintf("%v", v), 64)
return int64(f), nil
```

`float64` has a 53-bit mantissa, so any unsigned integer above 2^53 is silently rounded. This is reachable through the public API (`Int64()`, `Int64s()`, `Int64Map()`, `Int()`, ...), and unsigned ints are common in configs (sizes, IDs, epoch timestamps). Example:

```go
k.Load(confmap.Provider(map[string]interface{}{"u64": uint64(9007199254740993)}, "."), nil)
k.Int64("u64") // returns 9007199254740992, not 9007199254740993
```

### Fix

Add explicit unsigned cases. `uint8/16/32` always fit in `int64`. `uint`/`uint64` go through a small helper that returns an error when the value exceeds `math.MaxInt64`, rather than losing precision — this matches `toInt64`'s existing contract of returning an error on values it can't represent (e.g. unparseable strings).

I chose to **error on overflow** rather than saturate, to stay consistent with the existing error-return behavior; happy to switch to saturation if you'd prefer.

### Test

Added `TestInt64UnsignedPrecision` (through the public `Int64()` API). It fails before the change (`9007199254740992 != 9007199254740993`) and passes after. `gofmt`/`go vet` clean.