### PR TITLE
fix: skip env entries without '=' in env provider

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -410,10 +410,13 @@ github.com/apache/arrow/go/v12 v12.0.0/go.mod h1:d+tV/eHZZ7Dz7RPrFKtPK02tpr+c9/P
 github.com/apache/thrift v0.16.0 h1:qEy6UW60iVOlUy+b9ZR0d5WzUWYGOo4HfopoyBaNmoY=
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e h1:QEF07wC0T1rKkctt1RINW/+RMTVmiwxETico2l3gxJA=
+github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
+github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
+github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/campoy/embedmd v1.0.0 h1:V4kI2qTJJLf4J29RzI/MAt2c3Bl4dQSYPuflzwFH2hY=
 github.com/campoy/embedmd v1.0.0/go.mod h1:oxyr9RCiSXg0M3VJ3ks0UGfp98BpSSGr0kpiX3MzVl8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -523,7 +526,9 @@ github.com/hashicorp/go-msgpack/v2 v2.1.1/go.mod h1:upybraOAblm4S7rx0+jeNy+CWWhz
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.6/go.mod h1:QmrqtbKuxxSWTN3ETMPuB+VtEiBJ/A9XhoYGv8E1uD8=
 github.com/hashicorp/go-sockaddr v1.0.6/go.mod h1:uoUUmtwU7n9Dv3O4SNLeFvg0SxQ3lyjsj6+CCykpaxI=
 github.com/hashicorp/go-syslog v1.0.0 h1:KaodqZuhUoZereWVIYmpUgZysurB1kBLX2j0MwMrUAE=
+github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
+github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.5 h1:1M5hW1cunYeoXOqHwEb/GBDDHAFo0Yqb/uz/beC6LbE=
 github.com/hashicorp/mdns v1.0.5/go.mod h1:mtBihi+LeNXGtG8L9dX59gAEa12BDtBQSp4v/YAJqrc=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
@@ -583,6 +588,7 @@ github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsK
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
+github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7 h1:xoIK0ctDddBMnc74udxJYBqlo9Ylnsp1waqjLsnef20=
 github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7/go.mod h1:YARuvh7BUWHNhzDq2OM5tzR2RiCcN2D7sapiKyCel/M=
 github.com/prometheus/client_golang v1.11.1 h1:+4eQaD7vAZ6DsfsxB15hbE0odUjGI5ARs9yskGu1v4s=
@@ -846,6 +852,7 @@ gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22/go.mod h1:yeKp02qBN3iKW1OzL3M
 gopkg.in/vmihailenco/msgpack.v2 v2.9.2 h1:gjPqo9orRVlSAH/065qw3MsFCDpH7fa1KpiizXyllY4=
 gopkg.in/vmihailenco/msgpack.v2 v2.9.2/go.mod h1:/3Dn1Npt9+MYyLpYYXjInO/5jvMLamn+AEGwNEOatn8=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc h1:/hemPrYIhOhy8zYrNj+069zDB68us2sMGsfkFJO0iZs=

--- a/providers/env/env.go
+++ b/providers/env/env.go
@@ -86,6 +86,12 @@ func (e *Env) Read() (map[string]any, error) {
 	mp := make(map[string]any)
 	for _, k := range keys {
 		parts := strings.SplitN(k, "=", 2)
+		// os.Environ can yield bare entries without a '=' (e.g. an
+		// environment variable name with no value). Skip them so we
+		// don't index past the end of the slice.
+		if len(parts) < 2 {
+			continue
+		}
 
 		// If there's a transformation callback,
 		// run it through every key/value.

--- a/providers/env/env.go
+++ b/providers/env/env.go
@@ -85,26 +85,23 @@ func (e *Env) Read() (map[string]any, error) {
 
 	mp := make(map[string]any)
 	for _, k := range keys {
-		parts := strings.SplitN(k, "=", 2)
-		// os.Environ can yield bare entries without a '=' (e.g. an
-		// environment variable name with no value). Skip them so we
-		// don't index past the end of the slice.
-		if len(parts) < 2 {
+		// If there's no '=', skip it.
+		key, val, ok := strings.Cut(k, "=")
+		if !ok {
 			continue
 		}
 
-		// If there's a transformation callback,
-		// run it through every key/value.
+		// If there's a transformation callback, run it through every key/value.
 		if e.transform != nil {
-			key, value := e.transform(parts[0], parts[1])
+			key, val := e.transform(key, val)
 			// If the callback blanked the key, omit it.
 			if key == "" {
 				continue
 			}
 
-			mp[key] = value
+			mp[key] = val
 		} else {
-			mp[parts[0]] = parts[1]
+			mp[key] = val
 		}
 
 	}

--- a/providers/env/env_test.go
+++ b/providers/env/env_test.go
@@ -163,3 +163,19 @@ func TestRead(t *testing.T) {
 		},
 	})
 }
+
+func TestReadBareKey(t *testing.T) {
+	// An environment entry without a '=' (e.g. a variable name with no
+	// value) must be skipped, not cause an index-out-of-range panic.
+	env := Provider(".", Opt{
+		EnvironFunc: func() []string {
+			return []string{"TEST_GOOD=value", "BAREKEYWITHOUTEQUALS", "TEST_OTHER=other"}
+		},
+	})
+	envs, err := env.Read()
+	assert.Nil(t, err)
+	assert.Equal(t, "value", envs["TEST_GOOD"])
+	assert.Equal(t, "other", envs["TEST_OTHER"])
+	_, ok := envs["BAREKEYWITHOUTEQUALS"]
+	assert.False(t, ok)
+}

--- a/providers/env/env_test.go
+++ b/providers/env/env_test.go
@@ -164,9 +164,8 @@ func TestRead(t *testing.T) {
 	})
 }
 
-func TestReadBareKey(t *testing.T) {
-	// An environment entry without a '=' (e.g. a variable name with no
-	// value) must be skipped, not cause an index-out-of-range panic.
+func TestInvalidKey(t *testing.T) {
+	// An environment entry without a '=' should be silently skipped.
 	env := Provider(".", Opt{
 		EnvironFunc: func() []string {
 			return []string{"TEST_GOOD=value", "BAREKEYWITHOUTEQUALS", "TEST_OTHER=other"}


### PR DESCRIPTION
Read iterated os.Environ and indexed parts[1] after SplitN(k, "=", 2) without checking the length. A bare entry with no '=' yields a single element slice and panicked with an index out of range error. The fix skips entries that lack a '=' so malformed environment entries no longer crash config loading.