### PR TITLE
fix: handle uints, large int strings, and float overflow in toInt64

### DIFF
--- a/koanf.go
+++ b/koanf.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding"
 	"fmt"
+	"math"
 	"reflect"
 	"sort"
 	"strconv"
@@ -483,15 +484,51 @@ func toInt64(v any) (int64, error) {
 		return int64(i), nil
 	case int64:
 		return i, nil
+	case uint8:
+		return int64(i), nil
+	case uint16:
+		return int64(i), nil
+	case uint32:
+		return int64(i), nil
+	case uint:
+		return uintToInt64(uint64(i))
+	case uint64:
+		return uintToInt64(i)
 	}
 
 	// Force it to a string and try to convert.
-	f, err := strconv.ParseFloat(fmt.Sprintf("%v", v), 64)
+	s := fmt.Sprintf("%v", v)
+
+	// Try an integer first so that values beyond float64's exact range (2^53)
+	// don't lose precision in the fallback below.
+	if i, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return i, nil
+	}
+
+	f, err := strconv.ParseFloat(s, 64)
 	if err != nil {
 		return 0, err
 	}
 
+	// int64(f) is undefined for out-of-range values and yields a different
+	// number on each CPU architecture. The upper bound is 2^63 and not
+	// math.MaxInt64, which rounds up to 2^63 as a float64, letting overflows
+	// through.
+	if math.IsNaN(f) || f >= 1<<63 || f < math.MinInt64 {
+		return 0, fmt.Errorf("value %v overflows int64", v)
+	}
+
 	return int64(f), nil
+}
+
+// uintToInt64 converts an unsigned integer to int64, erroring on overflow
+// instead of wrapping around.
+func uintToInt64(v uint64) (int64, error) {
+	if v > math.MaxInt64 {
+		return 0, fmt.Errorf("value %d overflows int64", v)
+	}
+
+	return int64(v), nil
 }
 
 // toInt64 takes a `v any` value and if it is a float type,

--- a/tests/koanf_test.go
+++ b/tests/koanf_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"maps"
+	"math"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -2107,4 +2108,45 @@ func TestGetNilPointer(t *testing.T) {
 	assert.Nil(gotSlice)
 	_, ok = gotSlice.(*[]string)
 	assert.True(ok, "expected type *[]string, got %T", gotSlice)
+}
+
+// TestInt64Conversion tests Int64() conversions of values that don't fit in
+// an int64 or that lose precision in a float64 round-trip.
+func TestInt64Conversion(t *testing.T) {
+	assert := assert.New(t)
+	k := koanf.New(delim)
+
+	assert.Nil(k.Load(confmap.Provider(map[string]any{
+		// Values that fit.
+		"int64":     int64(math.MaxInt64),
+		"uint64":    uint64(math.MaxInt64),
+		"strmaxint": "9223372036854775807",
+		"strminint": "-9223372036854775808",
+		"str2p53":   "9007199254740993", // 2^53+1, inexact as a float64.
+		"float":     1.9,
+		"minfloat":  float64(math.MinInt64),
+		"strfloat":  "3.7",
+		// Values that don't.
+		"bigfloat":  float64(math.MaxInt64), // Rounds up to 2^63.
+		"hugefloat": 1e300,
+		"neghuge":   -1e300,
+		"inf":       math.Inf(1),
+		"neginf":    math.Inf(-1),
+		"nan":       math.NaN(),
+		"biguint64": uint64(math.MaxInt64) + 1,
+	}, delim), nil))
+
+	assert.Equal(int64(math.MaxInt64), k.Int64("int64"))
+	assert.Equal(int64(math.MaxInt64), k.Int64("uint64"))
+	assert.Equal(int64(math.MaxInt64), k.Int64("strmaxint"))
+	assert.Equal(int64(math.MinInt64), k.Int64("strminint"))
+	assert.Equal(int64(9007199254740993), k.Int64("str2p53"))
+	assert.Equal(int64(1), k.Int64("float"))
+	assert.Equal(int64(math.MinInt64), k.Int64("minfloat"))
+	assert.Equal(int64(3), k.Int64("strfloat"))
+
+	// Out of range must return 0, never a wrapped or architecture-dependent value.
+	for _, key := range []string{"bigfloat", "hugefloat", "neghuge", "inf", "neginf", "nan", "biguint64"} {
+		assert.Equal(int64(0), k.Int64(key), "Int64(%q) must be 0", key)
+	}
 }


### PR DESCRIPTION
Consolidates #428, #433 and #435 into one fix. Closes #434.

`toInt64()` handles the signed int types in a type switch and falls through to a `float64` round-trip for everything else. That path has three problems:

| input | before | after |
|---|---|---|
| `uint64(math.MaxUint64)` | `-9223372036854775808` | `0` |
| `"9007199254740993"` (2^53+1) | `9007199254740992` | `9007199254740993` |
| `{"n": 9223372036854775807}` | `-9223372036854775808` | `0` |

1. **Unsigned ints** aren't in the switch, so they take the float path and wrap.
2. **Integer strings** beyond float64's exact range (2^53) silently lose precision. Reachable via `env`, `dotenv` and any string-valued provider.
3. **`int64(f)` is undefined** when `f` is out of range. On amd64 `CVTTSD2SIQ` returns `MinInt64`; on arm64 `FCVTZSD` saturates instead, so the same config yields a different number per architecture. `encoding/json` decodes every number to a `float64`, and `float64(math.MaxInt64)` rounds *up* to 2^63 — so the largest legal `int64` in a JSON config was exactly the value that tripped it.

The guard is written against `2^63`, not `math.MaxInt64`: the latter is an untyped constant that converts to `float64` as the same rounded value, so `f > math.MaxInt64` is false for precisely the inputs that overflow. `math.MinInt64` *is* exactly representable, so `<` is correct on the low side. `NaN` compares false against everything and needs its own check.

Out-of-range values now return `0`, per the documented getter contract — *"or 0 if the path does not exist or if the value is not a valid int64"* — rather than a wrapped or architecture-dependent number. Inherited by `Int()`, `Ints`, `Int64s`, `Int64Map` and `Duration`.

Note this does not make `{"n": 9223372036854775807}` read back correctly — it can't, since `encoding/json` has already destroyed the precision by decoding to `float64`. That would need `UseNumber()` in the JSON parser.

`TestInt64Conversion` covers both sides; it fails on master on all three counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)