### PR TITLE
MapKeys returns an empty slice for a natively-typed map

### DIFF
--- a/koanf.go
+++ b/koanf.go
@@ -416,13 +416,16 @@ func (ko *Koanf) MapKeys(path string) []string {
 		return out
 	}
 
-	mp, ok := o.(map[string]any)
-	if !ok {
+	// A value set with Set() or by a Provider such as structs keeps its native
+	// map type, so the keys have to be read through reflection too.
+	rv := reflect.ValueOf(o)
+	if rv.Kind() != reflect.Map || rv.Type().Key().Kind() != reflect.String {
 		return out
 	}
-	out = make([]string, 0, len(mp))
-	for k := range mp {
-		out = append(out, k)
+
+	out = make([]string, 0, rv.Len())
+	for _, k := range rv.MapKeys() {
+		out = append(out, k.String())
 	}
 	sort.Strings(out)
 	return out

--- a/tests/koanf_test.go
+++ b/tests/koanf_test.go
@@ -1533,6 +1533,17 @@ func TestBoolsNativeSlice(t *testing.T) {
 	assert.Equal([]bool{true, false, true}, k.Bools("bools"))
 }
 
+func TestMapKeysNativeMap(t *testing.T) {
+	assert := assert.New(t)
+
+	k := koanf.New(delim)
+	assert.NoError(k.Load(confmap.Provider(map[string]any{
+		"ints": map[string]int64{"a": 1, "b": 2},
+	}, "."), nil))
+
+	assert.Equal([]string{"a", "b"}, k.MapKeys("ints"), "map keys mismatch for a natively-typed map")
+}
+
 // waitTimeout waits for the waitgroup for the specified max timeout.
 // Returns true if waiting timed out.
 func waitTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {


### PR DESCRIPTION

## Problem

`Koanf.MapKeys(path)` is documented to return the sorted keys of the map at
`path`, or an empty slice "if the path is not a map". A value at a key path
does not have to be `map[string]any` to be a map, though: `Set()`, or a
provider such as `structs`, can put a `map[string]T` (`map[string]int64`,
`map[string]bool`, ...) directly into the config tree, and `Koanf.Get()`
returns it verbatim with its concrete type intact (`koanf.go`'s `Get` only
special-cases `map[string]any` for its copy, everything else falls through
to `copystructure.Copy`, which preserves the type).

`MapKeys` only checked `o.(map[string]any)`, so a natively-typed map failed
that assertion and produced `[]string{}` even though the map plainly has
keys - a silent contract violation, not a "not a map" case.

```go
k := koanf.New(".")
k.Load(confmap.Provider(map[string]any{
    "ints": map[string]int64{"a": 1, "b": 2},
}, "."), nil)

k.Get("ints")      // map[string]int64{"a":1, "b":2}
k.MapKeys("ints")  // []string{} -- should be []string{"a", "b"}
```

## Root cause

`koanf.go:410-429`, `MapKeys`:

```go
mp, ok := o.(map[string]any)
if !ok {
    return out
}
```

This is the same shape of bug already fixed for `Int64Map`, `Float64Map` and
`BoolMap` in #444 (checking only `map[string]any` and silently dropping the
natively-typed sibling), applied to a different getter that PR does not
touch.

## Fix

Since `MapKeys` only needs the keys and does not care about the value type,
the fix reads them through reflection instead of enumerating every possible
`map[string]T`: any map whose key kind is `string` is accepted, `map[string]any`
included.

```go
rv := reflect.ValueOf(o)
if rv.Kind() != reflect.Map || rv.Type().Key().Kind() != reflect.String {
    return out
}

out = make([]string, 0, rv.Len())
for _, k := range rv.MapKeys() {
    out = append(out, k.String())
}
sort.Strings(out)
```

`reflect` and `sort` are already imported in `koanf.go` for other methods.
